### PR TITLE
feature: Support defining IBC-enabled and IBC keeper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ backtrace = ["anyhow/backtrace"]
 [dependencies]
 cw-utils = "0.16"
 cw-storage-plus = "0.16"
-cosmwasm-std = { version = "1.0", features = ["staking", "stargate"] }
+cosmwasm-std = { version = "1.0", features = ["staking"] }
 itertools = "0.10.1"
 schemars = "0.8.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["iterator", "staking"]
+ibc3 = ["stargate", "cosmwasm-std/ibc3"]
 iterator = ["cosmwasm-std/iterator"]
 stargate = ["cosmwasm-std/stargate"]
 staking = ["cosmwasm-std/staking"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use serde::Serialize;
 use crate::bank::{Bank, BankKeeper, BankSudo};
 use crate::contracts::Contract;
 use crate::executor::{AppResponse, Executor};
-use crate::gov::Gov;
-use crate::ibc::Ibc;
+use crate::gov::{FailingGovKeeper, Gov};
+use crate::ibc::{FailingIbcKeeper, Ibc};
 use crate::module::{FailingModule, Module};
 use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
 use crate::transactions::transactional;
@@ -37,7 +37,8 @@ pub type BasicApp<ExecC = Empty, QueryC = Empty> = App<
     WasmKeeper<ExecC, QueryC>,
     StakeKeeper,
     DistributionKeeper,
-    FailingModule<IbcMsg, IbcQuery, Empty>,
+    FailingIbcKeeper,
+    FailingGovKeeper,
 >;
 
 /// Router is a persisted state. You can query this.
@@ -51,8 +52,8 @@ pub struct App<
     Wasm = WasmKeeper<Empty, Empty>,
     Staking = StakeKeeper,
     Distr = DistributionKeeper,
-    Ibc = FailingModule<IbcMsg, IbcQuery, Empty>,
-    Gov = FailingModule<GovMsg, Empty, Empty>,
+    Ibc = FailingIbcKeeper,
+    Gov = FailingGovKeeper,
 > {
     router: Router<Bank, Custom, Wasm, Staking, Distr, Ibc, Gov>,
     api: Api,
@@ -84,8 +85,8 @@ impl BasicApp {
                 WasmKeeper<Empty, Empty>,
                 StakeKeeper,
                 DistributionKeeper,
-                FailingModule<IbcMsg, IbcQuery, Empty>,
-                FailingModule<GovMsg, Empty, Empty>,
+                FailingIbcKeeper,
+                FailingGovKeeper,
             >,
             &dyn Api,
             &mut dyn Storage,
@@ -108,8 +109,8 @@ where
             WasmKeeper<ExecC, QueryC>,
             StakeKeeper,
             DistributionKeeper,
-            FailingModule<IbcMsg, IbcQuery, Empty>,
-            FailingModule<GovMsg, Empty, Empty>,
+            FailingIbcKeeper,
+            FailingGovKeeper,
         >,
         &dyn Api,
         &mut dyn Storage,
@@ -176,8 +177,8 @@ pub type BasicAppBuilder<ExecC, QueryC> = AppBuilder<
     WasmKeeper<ExecC, QueryC>,
     StakeKeeper,
     DistributionKeeper,
-    FailingModule<IbcMsg, IbcQuery, Empty>,
-    FailingModule<GovMsg, Empty, Empty>,
+    FailingIbcKeeper,
+    FailingGovKeeper,
 >;
 
 /// Utility to build App in stages. If particular items wont be set, defaults would be used
@@ -203,8 +204,8 @@ impl Default
         WasmKeeper<Empty, Empty>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
-        FailingModule<GovMsg, Empty, Empty>,
+        FailingIbcKeeper,
+        FailingGovKeeper,
     >
 {
     fn default() -> Self {
@@ -221,8 +222,8 @@ impl
         WasmKeeper<Empty, Empty>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
-        FailingModule<GovMsg, Empty, Empty>,
+        FailingIbcKeeper,
+        FailingGovKeeper,
     >
 {
     /// Creates builder with default components working with empty exec and query messages.
@@ -236,8 +237,8 @@ impl
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: FailingIbcKeeper::new(),
+            gov: FailingGovKeeper::new(),
         }
     }
 }
@@ -251,8 +252,8 @@ impl<ExecC, QueryC>
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
-        FailingModule<GovMsg, Empty, Empty>,
+        FailingIbcKeeper,
+        FailingGovKeeper,
     >
 where
     ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
@@ -270,8 +271,8 @@ where
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: FailingIbcKeeper::new(),
+            gov: FailingGovKeeper::new(),
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,12 @@
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use anyhow::bail;
-use anyhow::Result as AnyResult;
+use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_std::{
     from_slice, to_binary, Addr, Api, Binary, BlockInfo, ContractResult, CosmosMsg, CustomQuery,
-    Empty, GovMsg, IbcMsg, IbcQuery, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record,
-    Storage, SystemError, SystemResult,
+    Empty, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record, Storage, SystemError,
+    SystemResult,
 };
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
@@ -122,7 +121,7 @@ where
 impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT> Querier
     for App<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
-    CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
     BankT: Bank,
@@ -144,7 +143,7 @@ where
 impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT> Executor<CustomT::ExecT>
     for App<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
-    CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
     BankT: Bank,
@@ -694,7 +693,7 @@ where
     DistrT: Distribution,
     IbcT: Ibc,
     GovT: Gov,
-    CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     /// This registers contract code (like uploading wasm bytecode on a chain),
@@ -717,7 +716,7 @@ where
 impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
     App<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
-    CustomT::ExecT: std::fmt::Debug + PartialEq + Clone + JsonSchema + DeserializeOwned + 'static,
+    CustomT::ExecT: Debug + PartialEq + Clone + JsonSchema + DeserializeOwned + 'static,
     CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
     BankT: Bank,
@@ -835,7 +834,7 @@ pub struct Router<Bank, Custom, Wasm, Staking, Distr, Ibc, Gov> {
 impl<BankT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
     Router<BankT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
-    CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
     CustomT: Module,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
@@ -1079,7 +1078,7 @@ impl<'a, ExecC, QueryC> RouterQuerier<'a, ExecC, QueryC> {
 
 impl<'a, ExecC, QueryC> Querier for RouterQuerier<'a, ExecC, QueryC>
 where
-    ExecC: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    ExecC: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     QueryC: CustomQuery + DeserializeOwned + 'static,
 {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
@@ -1089,7 +1088,7 @@ where
                 return SystemResult::Err(SystemError::InvalidRequest {
                     error: format!("Parsing query request: {}", e),
                     request: bin_request.into(),
-                })
+                });
             }
         };
         let contract_result: ContractResult<Binary> = self
@@ -1102,7 +1101,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use cosmwasm_std::testing::MockQuerier;
     use cosmwasm_std::{
         coin, coins, to_binary, AllBalanceResponse, Attribute, BankMsg, BankQuery, Coin, Event,
@@ -1114,12 +1112,14 @@ mod test {
     use crate::test_helpers::{CustomMsg, EmptyMsg};
     use crate::transactions::StorageTransaction;
 
+    use super::*;
+
     fn get_balance<BankT, ApiT, StorageT, CustomT, WasmT>(
         app: &App<BankT, ApiT, StorageT, CustomT, WasmT>,
         addr: &Addr,
     ) -> Vec<Coin>
     where
-        CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+        CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
         CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
         WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
         BankT: Bank,
@@ -1225,7 +1225,7 @@ mod test {
                 creator: owner.clone(),
                 admin: None,
                 label: "Payout".to_owned(),
-                created: app.block_info().height
+                created: app.block_info().height,
             }
         );
 
@@ -1523,13 +1523,13 @@ mod test {
     // this demonstrates that we can mint tokens and send from other accounts via a custom module,
     // as an example of ability to do privileged actions
     mod custom_handler {
-        use super::*;
-
         use anyhow::{bail, Result as AnyResult};
         use cw_storage_plus::Item;
         use serde::{Deserialize, Serialize};
 
         use crate::Executor;
+
+        use super::*;
 
         const LOTTERY: Item<Coin> = Item::new("lottery");
         const PITY: Item<Coin> = Item::new("pity");
@@ -1762,7 +1762,7 @@ mod test {
         rcpt: &Addr,
     ) -> Vec<Coin>
     where
-        CustomT::ExecT: Clone + fmt::Debug + PartialEq + JsonSchema,
+        CustomT::ExecT: Clone + Debug + PartialEq + JsonSchema,
         CustomT::QueryT: CustomQuery + DeserializeOwned,
         WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
         BankT: Bank,
@@ -2047,9 +2047,9 @@ mod test {
     }
 
     mod reply_data_overwrite {
-        use super::*;
-
         use echo::EXECUTE_REPLY_BASE_ID;
+
+        use super::*;
 
         fn make_echo_submsg(
             contract: Addr,
@@ -2619,8 +2619,9 @@ mod test {
     }
 
     mod custom_messages {
-        use super::*;
         use crate::custom_handler::CachingCustomHandler;
+
+        use super::*;
 
         #[test]
         fn triggering_custom_msg() {
@@ -2664,9 +2665,11 @@ mod test {
     }
 
     mod protobuf_wrapped_data {
-        use super::*;
-        use crate::test_helpers::contracts::echo::EXECUTE_REPLY_BASE_ID;
         use cw_utils::parse_instantiate_response_data;
+
+        use crate::test_helpers::contracts::echo::EXECUTE_REPLY_BASE_ID;
+
+        use super::*;
 
         #[test]
         fn instantiate_wrapped_properly() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -948,7 +948,9 @@ where
             CosmosMsg::Distribution(msg) => self
                 .distribution
                 .execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "stargate")]
             CosmosMsg::Ibc(msg) => self.ibc.execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "stargate")]
             CosmosMsg::Gov(msg) => self.gov.execute(api, storage, self, block, sender, msg),
             _ => bail!("Cannot execute {:?}", msg),
         }
@@ -970,6 +972,7 @@ where
             QueryRequest::Bank(req) => self.bank.query(api, storage, &querier, block, req),
             QueryRequest::Custom(req) => self.custom.query(api, storage, &querier, block, req),
             QueryRequest::Staking(req) => self.staking.query(api, storage, &querier, block, req),
+            #[cfg(feature = "stargate")]
             QueryRequest::Ibc(req) => self.ibc.query(api, storage, &querier, block, req),
             _ => unimplemented!(),
         }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -1,9 +1,8 @@
-use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
 use std::error::Error;
-use std::fmt::{self, Debug, Display};
+use std::fmt::{Debug, Display};
 use std::ops::Deref;
 
+use anyhow::{anyhow, bail, Result as AnyResult};
 use cosmwasm_std::{
     from_slice, Binary, CosmosMsg, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo,
     QuerierWrapper, Reply, Response, SubMsg,
@@ -14,13 +13,13 @@ use cosmwasm_std::{
     IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
     IbcReceiveResponse,
 };
-
-use anyhow::{anyhow, bail, Result as AnyResult};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 
 /// Interface to call into a Contract
 pub trait Contract<T, Q = Empty>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: Clone + Debug + PartialEq + JsonSchema,
     Q: CustomQuery,
 {
     fn execute(
@@ -192,7 +191,7 @@ pub struct ContractWrapper<
     E10: Display + Debug + Send + Sync + 'static,
     E11: Display + Debug + Send + Sync + 'static,
     E12: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: Clone + Debug + PartialEq + JsonSchema,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     execute_fn: ContractClosure<T1, C, E1, Q>,
@@ -212,7 +211,7 @@ where
     E1: Display + Debug + Send + Sync + 'static,
     E2: Display + Debug + Send + Sync + 'static,
     E3: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    C: Clone + Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn new(
@@ -270,7 +269,7 @@ where
     E10: Display + Debug + Send + Sync + 'static,
     E11: Display + Debug + Send + Sync + 'static,
     E12: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    C: Clone + Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn with_sudo<T4A, E4A>(
@@ -527,7 +526,7 @@ fn customize_fn<T, C, E, Q>(raw_fn: ContractFn<T, Empty, E, Empty>) -> ContractC
 where
     T: DeserializeOwned + 'static,
     E: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    C: Clone + Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     let customized = move |mut deps: DepsMut<Q>,
@@ -582,7 +581,7 @@ fn customize_permissioned_fn<T, C, E, Q>(
 where
     T: DeserializeOwned + 'static,
     E: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    C: Clone + Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     let customized = move |deps: DepsMut<Q>, env: Env, msg: T| -> Result<Response<C>, E> {
@@ -593,7 +592,7 @@ where
 
 fn customize_response<C>(resp: Response<Empty>) -> Response<C>
 where
-    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: Clone + Debug + PartialEq + JsonSchema,
 {
     let mut customized_resp = Response::<C>::new()
         .add_submessages(resp.messages.into_iter().map(customize_msg::<C>))
@@ -605,7 +604,7 @@ where
 
 fn customize_msg<C>(msg: SubMsg<Empty>) -> SubMsg<C>
 where
-    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: Clone + Debug + PartialEq + JsonSchema,
 {
     SubMsg {
         msg: match msg.msg {
@@ -646,7 +645,7 @@ where
     E10: Display + Debug + Send + Sync + 'static,
     E11: Display + Debug + Send + Sync + 'static,
     E12: Display + Debug + Send + Sync + 'static,
-    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: Clone + Debug + PartialEq + JsonSchema,
     Q: CustomQuery + DeserializeOwned,
 {
     fn execute(

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -8,6 +8,12 @@ use cosmwasm_std::{
     from_slice, Binary, CosmosMsg, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo,
     QuerierWrapper, Reply, Response, SubMsg,
 };
+#[cfg(feature = "stargate")]
+use cosmwasm_std::{
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
+};
 
 use anyhow::{anyhow, bail, Result as AnyResult};
 
@@ -40,6 +46,54 @@ where
     fn reply(&self, deps: DepsMut<Q>, env: Env, msg: Reply) -> AnyResult<Response<T>>;
 
     fn migrate(&self, deps: DepsMut<Q>, env: Env, msg: Vec<u8>) -> AnyResult<Response<T>>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_open(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelOpenMsg,
+    ) -> AnyResult<IbcChannelOpenResponse>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_connect(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelConnectMsg,
+    ) -> AnyResult<IbcBasicResponse>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_close(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelCloseMsg,
+    ) -> AnyResult<IbcBasicResponse>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_receive(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketReceiveMsg,
+    ) -> AnyResult<IbcReceiveResponse>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_ack(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketAckMsg,
+    ) -> AnyResult<IbcBasicResponse>;
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_timeout(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketTimeoutMsg,
+    ) -> AnyResult<IbcBasicResponse>;
 }
 
 type ContractFn<T, C, E, Q> =
@@ -47,12 +101,56 @@ type ContractFn<T, C, E, Q> =
 type PermissionedFn<T, C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T) -> Result<Response<C>, E>;
 type ReplyFn<C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: Reply) -> Result<Response<C>, E>;
 type QueryFn<T, E, Q> = fn(deps: Deps<Q>, env: Env, msg: T) -> Result<Binary, E>;
+#[cfg(feature = "stargate")]
+type IbcFn<T, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T) -> Result<IbcBasicResponse, E>;
+#[cfg(feature = "stargate")]
+type IbcOpenFn<E, Q> =
+    fn(deps: DepsMut<Q>, env: Env, msg: IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>;
+#[cfg(feature = "stargate")]
+type IbcReceiveFn<E, Q> =
+    fn(deps: DepsMut<Q>, env: Env, msg: IbcPacketReceiveMsg) -> Result<IbcReceiveResponse, E>;
 
 type ContractClosure<T, C, E, Q> =
     Box<dyn Fn(DepsMut<Q>, Env, MessageInfo, T) -> Result<Response<C>, E>>;
 type PermissionedClosure<T, C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, T) -> Result<Response<C>, E>>;
 type ReplyClosure<C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response<C>, E>>;
 type QueryClosure<T, E, Q> = Box<dyn Fn(Deps<Q>, Env, T) -> Result<Binary, E>>;
+#[cfg(feature = "stargate")]
+type IbcClosure<T, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, T) -> Result<IbcBasicResponse, E>>;
+#[cfg(feature = "stargate")]
+type IbcOpenClosure<E, Q> =
+    Box<dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>>;
+#[cfg(feature = "stargate")]
+type IbcReceiveClosure<E, Q> =
+    Box<dyn Fn(DepsMut<Q>, Env, IbcPacketReceiveMsg) -> Result<IbcReceiveResponse, E>>;
+
+struct IbcFns<E1, E2, E3, E4, E5, E6, Q>
+where
+    E1: Display + Debug + Send + Sync + 'static,
+    E2: Display + Debug + Send + Sync + 'static,
+    E3: Display + Debug + Send + Sync + 'static,
+    E4: Display + Debug + Send + Sync + 'static,
+    E5: Display + Debug + Send + Sync + 'static,
+    E6: Display + Debug + Send + Sync + 'static,
+    Q: CustomQuery,
+{
+    #[cfg(feature = "stargate")]
+    open_fn: IbcOpenClosure<E1, Q>,
+    #[cfg(feature = "stargate")]
+    connect_fn: IbcClosure<IbcChannelConnectMsg, E2, Q>,
+    #[cfg(feature = "stargate")]
+    close_fn: IbcClosure<IbcChannelCloseMsg, E3, Q>,
+    #[cfg(feature = "stargate")]
+    receive_fn: IbcReceiveClosure<E4, Q>,
+    #[cfg(feature = "stargate")]
+    ack_fn: IbcClosure<IbcPacketAckMsg, E5, Q>,
+    #[cfg(feature = "stargate")]
+    timeout_fn: IbcClosure<IbcPacketTimeoutMsg, E6, Q>,
+    #[cfg(not(feature = "stargate"))]
+    _phantom_data: std::marker::PhantomData<(E1, E2, E3, E4, E5, E6, Q)>,
+    #[cfg(not(feature = "stargate"))]
+    _infallible: std::convert::Infallible,
+}
 
 /// Wraps the exported functions from a contract and provides the normalized format
 /// Place T4 and E4 at the end, as we just want default placeholders for most contracts that don't have sudo
@@ -70,6 +168,12 @@ pub struct ContractWrapper<
     E5 = anyhow::Error,
     T6 = Empty,
     E6 = anyhow::Error,
+    E7 = anyhow::Error,
+    E8 = anyhow::Error,
+    E9 = anyhow::Error,
+    E10 = anyhow::Error,
+    E11 = anyhow::Error,
+    E12 = anyhow::Error,
 > where
     T1: DeserializeOwned + Debug,
     T2: DeserializeOwned,
@@ -82,6 +186,12 @@ pub struct ContractWrapper<
     E4: Display + Debug + Send + Sync + 'static,
     E5: Display + Debug + Send + Sync + 'static,
     E6: Display + Debug + Send + Sync + 'static,
+    E7: Display + Debug + Send + Sync + 'static,
+    E8: Display + Debug + Send + Sync + 'static,
+    E9: Display + Debug + Send + Sync + 'static,
+    E10: Display + Debug + Send + Sync + 'static,
+    E11: Display + Debug + Send + Sync + 'static,
+    E12: Display + Debug + Send + Sync + 'static,
     C: Clone + fmt::Debug + PartialEq + JsonSchema,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
@@ -91,6 +201,7 @@ pub struct ContractWrapper<
     sudo_fn: Option<PermissionedClosure<T4, C, E4, Q>>,
     reply_fn: Option<ReplyClosure<C, E5, Q>>,
     migrate_fn: Option<PermissionedClosure<T6, C, E6, Q>>,
+    ibc_fns: Option<IbcFns<E7, E8, E9, E10, E11, E12, Q>>,
 }
 
 impl<T1, T2, T3, E1, E2, E3, C, Q> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q>
@@ -116,6 +227,7 @@ where
             sudo_fn: None,
             reply_fn: None,
             migrate_fn: None,
+            ibc_fns: None,
         }
     }
 
@@ -133,12 +245,13 @@ where
             sudo_fn: None,
             reply_fn: None,
             migrate_fn: None,
+            ibc_fns: None,
         }
     }
 }
 
-impl<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
-    ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
+impl<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6, E7, E8, E9, E10, E11, E12>
+    ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6, E7, E8, E9, E10, E11, E12>
 where
     T1: DeserializeOwned + Debug + 'static,
     T2: DeserializeOwned + 'static,
@@ -151,13 +264,39 @@ where
     E4: Display + Debug + Send + Sync + 'static,
     E5: Display + Debug + Send + Sync + 'static,
     E6: Display + Debug + Send + Sync + 'static,
+    E7: Display + Debug + Send + Sync + 'static,
+    E8: Display + Debug + Send + Sync + 'static,
+    E9: Display + Debug + Send + Sync + 'static,
+    E10: Display + Debug + Send + Sync + 'static,
+    E11: Display + Debug + Send + Sync + 'static,
+    E12: Display + Debug + Send + Sync + 'static,
     C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn with_sudo<T4A, E4A>(
         self,
         sudo_fn: PermissionedFn<T4A, C, E4A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4A, E4A, E5, T6, E6>
+    ) -> ContractWrapper<
+        T1,
+        T2,
+        T3,
+        E1,
+        E2,
+        E3,
+        C,
+        Q,
+        T4A,
+        E4A,
+        E5,
+        T6,
+        E6,
+        E7,
+        E8,
+        E9,
+        E10,
+        E11,
+        E12,
+    >
     where
         T4A: DeserializeOwned + 'static,
         E4A: Display + Debug + Send + Sync + 'static,
@@ -169,13 +308,34 @@ where
             sudo_fn: Some(Box::new(sudo_fn)),
             reply_fn: self.reply_fn,
             migrate_fn: self.migrate_fn,
+            ibc_fns: self.ibc_fns,
         }
     }
 
     pub fn with_sudo_empty<T4A, E4A>(
         self,
         sudo_fn: PermissionedFn<T4A, Empty, E4A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4A, E4A, E5, T6, E6>
+    ) -> ContractWrapper<
+        T1,
+        T2,
+        T3,
+        E1,
+        E2,
+        E3,
+        C,
+        Q,
+        T4A,
+        E4A,
+        E5,
+        T6,
+        E6,
+        E7,
+        E8,
+        E9,
+        E10,
+        E11,
+        E12,
+    >
     where
         T4A: DeserializeOwned + 'static,
         E4A: Display + Debug + Send + Sync + 'static,
@@ -187,13 +347,14 @@ where
             sudo_fn: Some(customize_permissioned_fn(sudo_fn)),
             reply_fn: self.reply_fn,
             migrate_fn: self.migrate_fn,
+            ibc_fns: self.ibc_fns,
         }
     }
 
     pub fn with_reply<E5A>(
         self,
         reply_fn: ReplyFn<C, E5A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6>
+    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6, E7, E8, E9, E10, E11, E12>
     where
         E5A: Display + Debug + Send + Sync + 'static,
     {
@@ -204,6 +365,7 @@ where
             sudo_fn: self.sudo_fn,
             reply_fn: Some(Box::new(reply_fn)),
             migrate_fn: self.migrate_fn,
+            ibc_fns: self.ibc_fns,
         }
     }
 
@@ -211,7 +373,7 @@ where
     pub fn with_reply_empty<E5A>(
         self,
         reply_fn: ReplyFn<Empty, E5A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6>
+    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6, E7, E8, E9, E10, E11, E12>
     where
         E5A: Display + Debug + Send + Sync + 'static,
     {
@@ -222,13 +384,34 @@ where
             sudo_fn: self.sudo_fn,
             reply_fn: Some(customize_permissioned_fn(reply_fn)),
             migrate_fn: self.migrate_fn,
+            ibc_fns: self.ibc_fns,
         }
     }
 
     pub fn with_migrate<T6A, E6A>(
         self,
         migrate_fn: PermissionedFn<T6A, C, E6A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6A, E6A>
+    ) -> ContractWrapper<
+        T1,
+        T2,
+        T3,
+        E1,
+        E2,
+        E3,
+        C,
+        Q,
+        T4,
+        E4,
+        E5,
+        T6A,
+        E6A,
+        E7,
+        E8,
+        E9,
+        E10,
+        E11,
+        E12,
+    >
     where
         T6A: DeserializeOwned + 'static,
         E6A: Display + Debug + Send + Sync + 'static,
@@ -240,13 +423,34 @@ where
             sudo_fn: self.sudo_fn,
             reply_fn: self.reply_fn,
             migrate_fn: Some(Box::new(migrate_fn)),
+            ibc_fns: self.ibc_fns,
         }
     }
 
     pub fn with_migrate_empty<T6A, E6A>(
         self,
         migrate_fn: PermissionedFn<T6A, Empty, E6A, Q>,
-    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6A, E6A>
+    ) -> ContractWrapper<
+        T1,
+        T2,
+        T3,
+        E1,
+        E2,
+        E3,
+        C,
+        Q,
+        T4,
+        E4,
+        E5,
+        T6A,
+        E6A,
+        E7,
+        E8,
+        E9,
+        E10,
+        E11,
+        E12,
+    >
     where
         T6A: DeserializeOwned + 'static,
         E6A: Display + Debug + Send + Sync + 'static,
@@ -258,6 +462,63 @@ where
             sudo_fn: self.sudo_fn,
             reply_fn: self.reply_fn,
             migrate_fn: Some(customize_permissioned_fn(migrate_fn)),
+            ibc_fns: self.ibc_fns,
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn with_ibc<E7A, E8A, E9A, E10A, E11A, E12A>(
+        self,
+        open_fn: IbcOpenFn<E7A, Q>,
+        connect_fn: IbcFn<IbcChannelConnectMsg, E8A, Q>,
+        close_fn: IbcFn<IbcChannelCloseMsg, E9A, Q>,
+        receive_fn: IbcReceiveFn<E10A, Q>,
+        ack_fn: IbcFn<IbcPacketAckMsg, E11A, Q>,
+        timeout_fn: IbcFn<IbcPacketTimeoutMsg, E12A, Q>,
+    ) -> ContractWrapper<
+        T1,
+        T2,
+        T3,
+        E1,
+        E2,
+        E3,
+        C,
+        Q,
+        T4,
+        E4,
+        E5,
+        T6,
+        E6,
+        E7A,
+        E8A,
+        E9A,
+        E10A,
+        E11A,
+        E12A,
+    >
+    where
+        E7A: Display + Debug + Send + Sync + 'static,
+        E8A: Display + Debug + Send + Sync + 'static,
+        E9A: Display + Debug + Send + Sync + 'static,
+        E10A: Display + Debug + Send + Sync + 'static,
+        E11A: Display + Debug + Send + Sync + 'static,
+        E12A: Display + Debug + Send + Sync + 'static,
+    {
+        ContractWrapper {
+            execute_fn: self.execute_fn,
+            instantiate_fn: self.instantiate_fn,
+            query_fn: self.query_fn,
+            sudo_fn: self.sudo_fn,
+            reply_fn: self.reply_fn,
+            migrate_fn: self.migrate_fn,
+            ibc_fns: Some(IbcFns {
+                open_fn: Box::new(open_fn),
+                connect_fn: Box::new(connect_fn),
+                close_fn: Box::new(close_fn),
+                receive_fn: Box::new(receive_fn),
+                ack_fn: Box::new(ack_fn),
+                timeout_fn: Box::new(timeout_fn),
+            }),
         }
     }
 }
@@ -365,8 +626,8 @@ where
     }
 }
 
-impl<T1, T2, T3, E1, E2, E3, C, T4, E4, E5, T6, E6, Q> Contract<C, Q>
-    for ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
+impl<T1, T2, T3, E1, E2, E3, C, T4, E4, E5, T6, E6, E7, E8, E9, E10, E11, E12, Q> Contract<C, Q>
+    for ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6, E7, E8, E9, E10, E11, E12>
 where
     T1: DeserializeOwned + Debug + Clone,
     T2: DeserializeOwned + Debug + Clone,
@@ -379,6 +640,12 @@ where
     E4: Display + Debug + Send + Sync + 'static,
     E5: Display + Debug + Send + Sync + 'static,
     E6: Display + Debug + Send + Sync + 'static,
+    E7: Display + Debug + Send + Sync + 'static,
+    E8: Display + Debug + Send + Sync + 'static,
+    E9: Display + Debug + Send + Sync + 'static,
+    E10: Display + Debug + Send + Sync + 'static,
+    E11: Display + Debug + Send + Sync + 'static,
+    E12: Display + Debug + Send + Sync + 'static,
     C: Clone + fmt::Debug + PartialEq + JsonSchema,
     Q: CustomQuery + DeserializeOwned,
 {
@@ -432,6 +699,90 @@ where
         match &self.migrate_fn {
             Some(migrate) => migrate(deps, env, msg).map_err(|err| anyhow!(err)),
             None => bail!("migrate not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_open(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelOpenMsg,
+    ) -> AnyResult<IbcChannelOpenResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { open_fn, .. }) => open_fn(deps, env, msg).map_err(|err| anyhow!(err)),
+            None => bail!("IBC functions not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_connect(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelConnectMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { connect_fn, .. }) => {
+                connect_fn(deps, env, msg).map_err(|err| anyhow!(err))
+            }
+            None => bail!("IBC functions not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_channel_close(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcChannelCloseMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { close_fn, .. }) => close_fn(deps, env, msg).map_err(|err| anyhow!(err)),
+            None => bail!("IBC functions not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_receive(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketReceiveMsg,
+    ) -> AnyResult<IbcReceiveResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { receive_fn, .. }) => {
+                receive_fn(deps, env, msg).map_err(|err| anyhow!(err))
+            }
+            None => bail!("IBC functions not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_ack(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketAckMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { ack_fn, .. }) => ack_fn(deps, env, msg).map_err(|err| anyhow!(err)),
+            None => bail!("IBC functions not implemented for contract"),
+        }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_packet_timeout(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: IbcPacketTimeoutMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        match &self.ibc_fns {
+            Some(IbcFns { timeout_fn, .. }) => {
+                timeout_fn(deps, env, msg).map_err(|err| anyhow!(err))
+            }
+            None => bail!("IBC functions not implemented for contract"),
         }
     }
 }

--- a/src/gov.rs
+++ b/src/gov.rs
@@ -2,9 +2,14 @@ use cosmwasm_std::{Empty, GovMsg};
 
 use crate::{FailingModule, Module};
 
+#[cfg(not(feature = "stargate"))]
+compile_error!("Intended for use only with `stargate` feature enabled!");
+
 pub trait Gov: Module<ExecT = GovMsg, QueryT = Empty, SudoT = Empty> {}
 
 impl Gov for FailingModule<GovMsg, Empty, Empty> {}
+
+pub type FailingGovKeeper = FailingModule<GovMsg, Empty, Empty>;
 
 #[cfg(test)]
 mod test {

--- a/src/ibc.rs
+++ b/src/ibc.rs
@@ -2,9 +2,14 @@ use cosmwasm_std::{Empty, IbcMsg, IbcQuery};
 
 use crate::{FailingModule, Module};
 
+#[cfg(not(feature = "stargate"))]
+compile_error!("Intended for use only with `stargate` feature enabled!");
+
 pub trait Ibc: Module<ExecT = IbcMsg, QueryT = IbcQuery, SudoT = Empty> {}
 
 impl Ibc for FailingModule<IbcMsg, IbcQuery, Empty> {}
+
+pub type FailingIbcKeeper = FailingModule<IbcMsg, IbcQuery, Empty>;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,19 @@
 //!
 //! To understand the design of this module, please refer to `../DESIGN.md`
 
+pub use crate::app::{
+    custom_app, next_block, App, AppBuilder, BasicApp, BasicAppBuilder, CosmosRouter, Router,
+    SudoMsg,
+};
+pub use crate::bank::{Bank, BankKeeper, BankSudo};
+pub use crate::contracts::{Contract, ContractWrapper};
+pub use crate::executor::{AppResponse, Executor};
+pub use crate::gov::Gov;
+pub use crate::ibc::{FailingIbcKeeper, Ibc};
+pub use crate::module::{FailingModule, Module};
+pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};
+pub use crate::wasm::{Wasm, WasmKeeper, WasmSudo};
+
 mod app;
 mod bank;
 #[allow(clippy::type_complexity)]
@@ -23,14 +36,3 @@ mod staking;
 mod test_helpers;
 mod transactions;
 mod wasm;
-
-pub use crate::app::{
-    custom_app, next_block, App, AppBuilder, BasicApp, BasicAppBuilder, CosmosRouter, Router,
-    SudoMsg,
-};
-pub use crate::bank::{Bank, BankKeeper, BankSudo};
-pub use crate::contracts::{Contract, ContractWrapper};
-pub use crate::executor::{AppResponse, Executor};
-pub use crate::module::{FailingModule, Module};
-pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};
-pub use crate::wasm::{Wasm, WasmKeeper, WasmSudo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::app::{
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
-pub use crate::gov::Gov;
+pub use crate::gov::{FailingGovKeeper, Gov};
 pub use crate::ibc::{FailingIbcKeeper, Ibc};
 pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ mod contracts;
 pub mod custom_handler;
 pub mod error;
 mod executor;
+#[cfg_attr(not(feature = "stargate"), path = "mock_gov.rs")]
 mod gov;
+#[cfg_attr(not(feature = "stargate"), path = "mock_ibc.rs")]
 mod ibc;
 mod module;
 mod prefixed_storage;

--- a/src/mock_gov.rs
+++ b/src/mock_gov.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::Empty;
+
+use crate::{FailingModule, Module};
+
+#[cfg(feature = "stargate")]
+compile_error!("Intended for use only with `stargate` feature disabled!");
+
+pub trait Gov: Module<ExecT = Empty, QueryT = Empty, SudoT = Empty> {}
+
+impl Gov for FailingModule<Empty, Empty, Empty> {}
+
+pub type FailingGovKeeper = FailingModule<Empty, Empty, Empty>;

--- a/src/mock_ibc.rs
+++ b/src/mock_ibc.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::Empty;
+
+use crate::module::{FailingModule, Module};
+
+#[cfg(feature = "stargate")]
+compile_error!("Intended for use only with `stargate` feature disabled!");
+
+pub trait Ibc: Module<ExecT = Empty, QueryT = Empty, SudoT = Empty> {}
+
+impl Ibc for FailingModule<Empty, Empty, Empty> {}
+
+pub type FailingIbcKeeper = FailingModule<Empty, Empty, Empty>;

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeSet;
 
 use anyhow::{anyhow, bail, Result as AnyResult};
-use schemars::JsonSchema;
-
 use cosmwasm_std::{
     coin, ensure, ensure_eq, to_binary, Addr, AllDelegationsResponse, AllValidatorsResponse, Api,
     BankMsg, Binary, BlockInfo, BondedDenomResponse, Coin, CustomQuery, Decimal, Delegation,
@@ -10,6 +8,7 @@ use cosmwasm_std::{
     StakingQuery, Storage, Timestamp, Uint128, Validator, ValidatorResponse,
 };
 use cw_storage_plus::{Deque, Item, Map};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::app::CosmosRouter;
@@ -864,17 +863,17 @@ impl Module for DistributionKeeper {
 
 #[cfg(test)]
 mod test {
-    use crate::{app::MockRouter, BankKeeper, FailingModule, Router, WasmKeeper};
-
-    use super::*;
-
     use cosmwasm_std::{
         from_slice,
         testing::{mock_env, MockApi, MockStorage},
-        BalanceResponse, BankQuery, GovMsg, IbcMsg, IbcQuery,
+        BalanceResponse, BankQuery,
     };
+
     use crate::gov::FailingGovKeeper;
     use crate::ibc::FailingIbcKeeper;
+    use crate::{app::MockRouter, BankKeeper, FailingModule, Router, WasmKeeper};
+
+    use super::*;
 
     /// Type alias for default build `Router` to make its reference in typical scenario
     type BasicRouter<ExecC = Empty, QueryC = Empty> = Router<

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -873,6 +873,8 @@ mod test {
         testing::{mock_env, MockApi, MockStorage},
         BalanceResponse, BankQuery, GovMsg, IbcMsg, IbcQuery,
     };
+    use crate::gov::FailingGovKeeper;
+    use crate::ibc::FailingIbcKeeper;
 
     /// Type alias for default build `Router` to make its reference in typical scenario
     type BasicRouter<ExecC = Empty, QueryC = Empty> = Router<
@@ -881,8 +883,8 @@ mod test {
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
-        FailingModule<GovMsg, Empty, Empty>,
+        FailingIbcKeeper,
+        FailingGovKeeper,
     >;
 
     fn mock_router() -> BasicRouter {
@@ -892,8 +894,8 @@ mod test {
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: FailingIbcKeeper::new(),
+            gov: FailingGovKeeper::new(),
         }
     }
 

--- a/src/test_helpers/contracts/stargate.rs
+++ b/src/test_helpers/contracts/stargate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use cosmwasm_std::{
     Binary, CosmosMsg, Deps, DepsMut, Empty, Env, GovMsg, IbcMsg, MessageInfo, Response, StdResult,
 };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -943,6 +943,8 @@ mod test {
 
     use crate::app::Router;
     use crate::bank::BankKeeper;
+    use crate::gov::FailingGovKeeper;
+    use crate::ibc::FailingIbcKeeper;
     use crate::module::FailingModule;
     use crate::staking::{DistributionKeeper, StakeKeeper};
     use crate::test_helpers::contracts::{caller, error, payout};
@@ -958,8 +960,8 @@ mod test {
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
-        FailingModule<GovMsg, Empty, Empty>,
+        FailingIbcKeeper,
+        FailingGovKeeper,
     >;
 
     fn mock_router() -> BasicRouter {
@@ -969,8 +971,8 @@ mod test {
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: FailingIbcKeeper::new(),
+            gov: FailingGovKeeper::new(),
         }
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -8,6 +8,12 @@ use cosmwasm_std::{
     QuerierWrapper, Record, Reply, ReplyOn, Response, StdResult, Storage, SubMsg, SubMsgResponse,
     SubMsgResult, TransactionInfo, WasmMsg, WasmQuery,
 };
+#[cfg(feature = "stargate")]
+use cosmwasm_std::{
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
+};
 use prost::Message;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
@@ -793,6 +799,126 @@ where
             address,
             |contract, deps, env| contract.migrate(deps, env, msg),
         )?)
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_channel_open(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcChannelOpenMsg,
+    ) -> AnyResult<IbcChannelOpenResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_channel_open(deps, env, msg),
+        )
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_channel_connect(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcChannelConnectMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_channel_connect(deps, env, msg),
+        )
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_channel_close(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcChannelCloseMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_channel_close(deps, env, msg),
+        )
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_packet_receive(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcPacketReceiveMsg,
+    ) -> AnyResult<IbcReceiveResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_packet_receive(deps, env, msg),
+        )
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_packet_ack(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcPacketAckMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_packet_ack(deps, env, msg),
+        )
+    }
+
+    #[cfg(feature = "stargate")]
+    pub fn call_ibc_packet_timeout(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        address: Addr,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        msg: IbcPacketTimeoutMsg,
+    ) -> AnyResult<IbcBasicResponse> {
+        self.with_storage(
+            api,
+            storage,
+            router,
+            block,
+            address,
+            |contract, deps, env| contract.ibc_packet_timeout(deps, env, msg),
+        )
     }
 
     fn get_env<T: Into<Addr>>(&self, address: T, block: &BlockInfo) -> Env {


### PR DESCRIPTION
This PR extends the efforts of #9, which added the foundations for adding custom IBC keeper and thus support IBC messages.

This PR also makes it possible to compile `cw-multi-test` without the need of adding `stargate` as a required feature to `cosmwasm-std`, by defining mock versions of both the IBC and Governance keeper modules.