### PR TITLE
chore: add custom address generator support to WasmKeeper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod prefixed_storage;
 mod staking;
 mod test_helpers;
 mod transactions;
-pub mod wasm;
+mod wasm;
 
 pub use crate::app::{
     custom_app, next_block, App, AppBuilder, BasicApp, BasicAppBuilder, CosmosRouter, Router,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod prefixed_storage;
 mod staking;
 mod test_helpers;
 mod transactions;
-mod wasm;
+pub mod wasm;
 
 pub use crate::app::{
     custom_app, next_block, App, AppBuilder, BasicApp, BasicAppBuilder, CosmosRouter, Router,
@@ -31,4 +31,4 @@ pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};
-pub use crate::wasm::{Wasm, WasmKeeper, WasmSudo};
+pub use crate::wasm::{AddressGenerator, Wasm, WasmKeeper, WasmSudo};

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -102,6 +102,28 @@ pub struct WasmKeeper<ExecC, QueryC> {
     codes: HashMap<usize, Box<dyn Contract<ExecC, QueryC>>>,
     /// Just markers to make type elision fork when using it as `Wasm` trait
     _p: std::marker::PhantomData<QueryC>,
+    generator: Box<dyn AddressGenerator>,
+}
+
+pub trait AddressGenerator {
+    fn next_address(&self, storage: &mut dyn Storage) -> Addr;
+}
+
+#[derive(Debug)]
+struct SimpleAddressGenerator();
+
+impl AddressGenerator for SimpleAddressGenerator {
+    fn next_address(&self, storage: &mut dyn Storage) -> Addr {
+        let count = CONTRACTS
+            .range_raw(
+                &prefixed_read(storage, NAMESPACE_WASM),
+                None,
+                None,
+                Order::Ascending,
+            )
+            .count();
+        Addr::unchecked(format!("contract{}", count))
+    }
 }
 
 impl<ExecC, QueryC> Default for WasmKeeper<ExecC, QueryC> {
@@ -109,6 +131,7 @@ impl<ExecC, QueryC> Default for WasmKeeper<ExecC, QueryC> {
         Self {
             codes: HashMap::default(),
             _p: std::marker::PhantomData,
+            generator: Box::new(SimpleAddressGenerator()),
         }
     }
 }
@@ -274,6 +297,15 @@ where
 {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn new_with_custom_address_generator(generator: impl AddressGenerator + 'static) -> Self {
+        let default = Self::default();
+        Self {
+            codes: default.codes,
+            _p: default._p,
+            generator: Box::new(generator),
+        }
     }
 
     pub fn query_smart(
@@ -685,7 +717,7 @@ where
             bail!("Cannot init contract with unregistered code id");
         }
 
-        let addr = self.next_address(&prefixed_read(storage, NAMESPACE_WASM));
+        let addr = self.generator.next_address(storage);
 
         let info = ContractData {
             code_id,
@@ -879,17 +911,6 @@ where
         CONTRACTS
             .save(&mut prefixed(storage, NAMESPACE_WASM), address, contract)
             .map_err(Into::into)
-    }
-
-    // FIXME: better addr generation
-    fn next_address(&self, storage: &dyn Storage) -> Addr {
-        // FIXME: quite inefficient if we actually had 100s of contracts
-        let count = CONTRACTS
-            .range_raw(storage, None, None, Order::Ascending)
-            .count();
-        // we make this longer so it is not rejected by tests
-        // it is lowercase to be compatible with the MockApi implementation of cosmwasm-std >= 1.0.0-beta8
-        Addr::unchecked(format!("contract{}", count))
     }
 }
 


### PR DESCRIPTION
This PR adds the option to use custom address generator with `WasmKeeper` (which by default uses the existing address generator).

Rationale behind it being that some contracts, like ours, might perform address validations. In our case we need to use bech32-compatible addresses and the ones currently being generated (`contract{n}`) aren't such. 