### PR TITLE
minor: Expose `Ibc` trait for use by other crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::app::{
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
+pub use crate::ibc::Ibc;
 pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};
 pub use crate::wasm::{AddressGenerator, Wasm, WasmKeeper, WasmSudo};


### PR DESCRIPTION
Motivation: This would allow downstream crates to utilize the recently added IBC capabilities of the crate. As of now, there is no way to provide functioning handler for IBC messages.