### PR TITLE
Staking rewards fix

### DIFF
--- a/src/staking.rs
+++ b/src/staking.rs
@@ -2450,5 +2450,51 @@ mod test {
             .unwrap();
             assert_eq!(balance.amount.u128(), 55);
         }
+
+        #[test]
+        fn rewards_initial_wait() {
+            let (mut test_env, validator) =
+                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::zero()));
+            let delegator = Addr::unchecked("delegator");
+
+            // init balance
+            test_env
+                .router
+                .bank
+                .init_balance(&mut test_env.store, &delegator, vec![coin(100, "TOKEN")])
+                .unwrap();
+
+            // wait a year before staking
+            const YEAR: u64 = 60 * 60 * 24 * 365;
+            test_env.block.time = test_env.block.time.plus_seconds(YEAR);
+
+            // delegate some tokens
+            execute_stake(
+                &mut test_env,
+                delegator.clone(),
+                StakingMsg::Delegate {
+                    validator: validator.to_string(),
+                    amount: coin(100, "TOKEN"),
+                },
+            )
+            .unwrap();
+
+            // wait another year
+            test_env.block.time = test_env.block.time.plus_seconds(YEAR);
+
+            // query rewards
+            let response: DelegationResponse = query_stake(
+                &test_env,
+                StakingQuery::Delegation {
+                    delegator: delegator.to_string(),
+                    validator: validator.to_string(),
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                response.delegation.unwrap().accumulated_rewards,
+                vec![coin(10, "TOKEN")] // 10% of 100
+            );
+        }
     }
 }

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -289,13 +289,12 @@ impl StakeKeeper {
             validator_info.stake,
         );
 
-        // update validator info and delegators
+        // update validator info
+        validator_info.last_rewards_calculation = block.time;
+        VALIDATOR_INFO.save(staking_storage, validator, &validator_info)?;
+
+        // update delegators
         if !new_rewards.is_zero() {
-            validator_info.last_rewards_calculation = block.time;
-
-            // save updated validator
-            VALIDATOR_INFO.save(staking_storage, validator, &validator_info)?;
-
             let validator_addr = api.addr_validate(&validator_obj.address)?;
             // update all delegators
             for staker in validator_info.stakers.iter() {


### PR DESCRIPTION
closes #30

The timestamp was not updated if there were no rewards (e.g. because of no stake), causing the next call to assume a longer staking time than it actually had.