### PR TITLE
Easily ignore ibc messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -520,7 +520,10 @@ impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
         }
     }
 
-    /// Overwrites default ibc interface
+    /// Overwrites default ibc interface.
+    ///
+    /// If you wish to simply ignore/drop all returned IBC Messages, you can use the `IbcAcceptingModule` type.
+    ///     builder.with_ibc(IbcAcceptingModule::new())
     pub fn with_ibc<NewIbc: Ibc>(
         self,
         ibc: NewIbc,

--- a/src/ibc.rs
+++ b/src/ibc.rs
@@ -1,81 +1,81 @@
-use cosmwasm_std::{Empty, IbcMsg, IbcQuery};
+use cosmwasm_std::{Binary, Empty, IbcMsg, IbcQuery};
 
-use crate::{FailingModule, Module};
+use crate::{AppResponse, FailingModule, Module};
 
 pub trait Ibc: Module<ExecT = IbcMsg, QueryT = IbcQuery, SudoT = Empty> {}
 
 impl Ibc for FailingModule<IbcMsg, IbcQuery, Empty> {}
 
-#[cfg(test)]
-mod test {
-    use cosmwasm_std::{Addr, Binary, Empty, IbcMsg, IbcQuery};
+pub struct IbcAcceptingModule;
 
-    use crate::test_helpers::contracts::stargate::{contract, ExecMsg};
-    use crate::{App, AppBuilder, AppResponse, Executor, Module};
+impl Module for IbcAcceptingModule {
+    type ExecT = IbcMsg;
+    type QueryT = IbcQuery;
+    type SudoT = Empty;
 
-    use super::Ibc;
-
-    struct AcceptingModule;
-
-    impl Module for AcceptingModule {
-        type ExecT = IbcMsg;
-        type QueryT = IbcQuery;
-        type SudoT = Empty;
-
-        fn execute<ExecC, QueryC>(
-            &self,
-            _api: &dyn cosmwasm_std::Api,
-            _storage: &mut dyn cosmwasm_std::Storage,
-            _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-            _block: &cosmwasm_std::BlockInfo,
-            _sender: cosmwasm_std::Addr,
-            _msg: Self::ExecT,
-        ) -> anyhow::Result<crate::AppResponse>
-        where
-            ExecC: std::fmt::Debug
-                + Clone
-                + PartialEq
-                + schemars::JsonSchema
-                + serde::de::DeserializeOwned
-                + 'static,
-            QueryC: cosmwasm_std::CustomQuery + serde::de::DeserializeOwned + 'static,
-        {
-            Ok(AppResponse::default())
-        }
-
-        fn sudo<ExecC, QueryC>(
-            &self,
-            _api: &dyn cosmwasm_std::Api,
-            _storage: &mut dyn cosmwasm_std::Storage,
-            _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-            _block: &cosmwasm_std::BlockInfo,
-            _msg: Self::SudoT,
-        ) -> anyhow::Result<crate::AppResponse>
-        where
-            ExecC: std::fmt::Debug
-                + Clone
-                + PartialEq
-                + schemars::JsonSchema
-                + serde::de::DeserializeOwned
-                + 'static,
-            QueryC: cosmwasm_std::CustomQuery + serde::de::DeserializeOwned + 'static,
-        {
-            Ok(AppResponse::default())
-        }
-
-        fn query(
-            &self,
-            _api: &dyn cosmwasm_std::Api,
-            _storage: &dyn cosmwasm_std::Storage,
-            _querier: &dyn cosmwasm_std::Querier,
-            _block: &cosmwasm_std::BlockInfo,
-            _request: Self::QueryT,
-        ) -> anyhow::Result<cosmwasm_std::Binary> {
-            Ok(Binary::default())
-        }
+    fn execute<ExecC, QueryC>(
+        &self,
+        _api: &dyn cosmwasm_std::Api,
+        _storage: &mut dyn cosmwasm_std::Storage,
+        _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &cosmwasm_std::BlockInfo,
+        _sender: cosmwasm_std::Addr,
+        _msg: Self::ExecT,
+    ) -> anyhow::Result<crate::AppResponse>
+    where
+        ExecC: std::fmt::Debug
+            + Clone
+            + PartialEq
+            + schemars::JsonSchema
+            + serde::de::DeserializeOwned
+            + 'static,
+        QueryC: cosmwasm_std::CustomQuery + serde::de::DeserializeOwned + 'static,
+    {
+        Ok(AppResponse::default())
     }
 
-    impl Ibc for AcceptingModule {}
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn cosmwasm_std::Api,
+        _storage: &mut dyn cosmwasm_std::Storage,
+        _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &cosmwasm_std::BlockInfo,
+        _msg: Self::SudoT,
+    ) -> anyhow::Result<crate::AppResponse>
+    where
+        ExecC: std::fmt::Debug
+            + Clone
+            + PartialEq
+            + schemars::JsonSchema
+            + serde::de::DeserializeOwned
+            + 'static,
+        QueryC: cosmwasm_std::CustomQuery + serde::de::DeserializeOwned + 'static,
+    {
+        Ok(AppResponse::default())
+    }
+
+    fn query(
+        &self,
+        _api: &dyn cosmwasm_std::Api,
+        _storage: &dyn cosmwasm_std::Storage,
+        _querier: &dyn cosmwasm_std::Querier,
+        _block: &cosmwasm_std::BlockInfo,
+        _request: Self::QueryT,
+    ) -> anyhow::Result<cosmwasm_std::Binary> {
+        Ok(Binary::default())
+    }
+}
+
+impl Ibc for IbcAcceptingModule {}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::{Addr, Empty};
+
+    use crate::test_helpers::contracts::stargate::{contract, ExecMsg};
+    use crate::{App, AppBuilder, Executor};
+
+    use super::*;
 
     #[test]
     fn default_ibc() {
@@ -99,7 +99,7 @@ mod test {
     #[test]
     fn subsituting_ibc() {
         let mut app = AppBuilder::new()
-            .with_ibc(AcceptingModule)
+            .with_ibc(IbcAcceptingModule)
             .build(|_, _, _| ());
         let code = app.store_code(contract());
         let contract = app

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::app::{
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
-pub use crate::ibc::Ibc;
+pub use crate::ibc::{Ibc, IbcAcceptingModule};
 pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo};
 pub use crate::wasm::{AddressGenerator, Wasm, WasmKeeper, WasmSudo};


### PR DESCRIPTION
For mesh security testing, I want to be able to run the code that sends IBC packets without it failing. Maybe lost functionality, but not having existing functions panic.

I was going to add this to the code, then found we had this in test code, so I exposed it and added some docs on how to enable it. I'd love to get this in 0.16.5 so we can add ibc functionality to mesh-security without breaking the existing test suite (and just focus the new test suite on the ibc stuff) 