### PR TITLE
Fix contract wrapper generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "anyhow",
  "cosmwasm-std",

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -174,7 +174,7 @@ where
 
     pub fn with_sudo_empty<T4A, E4A>(
         self,
-        sudo_fn: PermissionedFn<T4A, Empty, E4A, Q>,
+        sudo_fn: PermissionedFn<T4A, Empty, E4A, Empty>,
     ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4A, E4A, E5, T6, E6>
     where
         T4A: DeserializeOwned + 'static,
@@ -210,7 +210,7 @@ where
     /// A correlate of new_with_empty
     pub fn with_reply_empty<E5A>(
         self,
-        reply_fn: ReplyFn<Empty, E5A, Q>,
+        reply_fn: ReplyFn<Empty, E5A, Empty>,
     ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6>
     where
         E5A: Display + Debug + Send + Sync + 'static,
@@ -245,7 +245,7 @@ where
 
     pub fn with_migrate_empty<T6A, E6A>(
         self,
-        migrate_fn: PermissionedFn<T6A, Empty, E6A, Q>,
+        migrate_fn: PermissionedFn<T6A, Empty, E6A, Empty>,
     ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6A, E6A>
     where
         T6A: DeserializeOwned + 'static,
@@ -316,7 +316,7 @@ where
 }
 
 fn customize_permissioned_fn<T, C, E, Q>(
-    raw_fn: PermissionedFn<T, Empty, E, Q>,
+    raw_fn: PermissionedFn<T, Empty, E, Empty>,
 ) -> PermissionedClosure<T, C, E, Q>
 where
     T: DeserializeOwned + 'static,
@@ -324,7 +324,8 @@ where
     C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
     Q: CustomQuery + DeserializeOwned + 'static,
 {
-    let customized = move |deps: DepsMut<Q>, env: Env, msg: T| -> Result<Response<C>, E> {
+    let customized = move |mut deps: DepsMut<Q>, env: Env, msg: T| -> Result<Response<C>, E> {
+        let deps = decustomize_deps_mut(&mut deps);
         raw_fn(deps, env, msg).map(customize_response::<C>)
     };
     Box::new(customized)


### PR DESCRIPTION
These changes replace generic `Q` with `Empty` in such methods as `ContractWrapper::with_reply_empty`.

We use shared testing mocks within different `App` types and custom modules. I only managed to do it having the PR changes. Here is an [example](https://github.com/astroport-fi/astroport-core/blob/demo/cross_app_mock/contracts/tokenomics/staking/tests/fix_contract_wrapper_generics.rs). [This](https://github.com/astroport-fi/astroport-core/blob/2cda01cde47d975419a6cfaf9ca923015fff99b1/contracts/tokenomics/staking/Cargo.toml#L34) line can be replaced with the next one to see the issue.

Is there any reason to use generic `Q` instead of `Empty`, which is used in `ContractWrapper::new_with_empty`, and any more elegant way to achieve that, or do these changes make sense?