### PR TITLE
Remove direct k256 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ version = "0.16.5"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
+ "cw-storage-plus",
  "cw-utils",
  "derivative",
  "itertools",
@@ -249,17 +249,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -275,15 +264,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d0cac456f98b4339b78e890fbe60e4dfe888c87abacc1129fc3fe34bbe20a"
+checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
- "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2",
- "k256",
  "schemars",
  "semver",
  "serde",
@@ -292,15 +279,16 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.16.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
+checksum = "29ac2dc7a55ad64173ca1e0a46697c31b7a5c51342f55a1e84a724da4eb99908"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.16.0",
+ "cw-storage-plus",
  "schemars",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -244,7 +244,6 @@ dependencies = [
  "cw-utils",
  "derivative",
  "itertools",
- "k256",
  "prost",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,6 @@ anyhow = "1.0.41"
 thiserror = "1.0"
 derivative = "2"
 
-# We don't use the following dependencies directly. They're dependencies of our dependencies.
-# We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.
-# Once we bump `cosmwasm-*` deps to a version after `1.1.5`, we can remove these.
-k256 = { version = "0.11.1", features = ["ecdsa"] }
-
 [dev-dependencies]
 # We don't use the following dependencies directly. They're dependencies of our dependencies.
 # We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw-utils = "1.0"
+cw-utils = "1.0.1"
 cw-storage-plus = "1.0"
 cosmwasm-std = { version = "1.2", features = ["staking", "stargate"] }
 itertools = "0.10.1"


### PR DESCRIPTION
k256 should only be pulled in through cosmwasm-crypto, not cw-multi-test or cw-utils. This PR fixes that.