### PR TITLE
Derive Clone for App

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,7 @@ pub type BasicApp<ExecC = Empty, QueryC = Empty> = App<
 /// Router is a persisted state. You can query this.
 /// Execution generally happens on the RouterCache, which then can be atomically committed or rolled back.
 /// We offer .execute() as a wrapper around cache, execute, commit/rollback process.
+#[derive(Clone)]
 pub struct App<
     Bank = BankKeeper,
     Api = MockApi,
@@ -821,6 +822,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct Router<Bank, Custom, Wasm, Staking, Distr, Ibc, Gov> {
     // this can remain crate-only as all special functions are wired up to app currently
     // we need to figure out another format for wasm, as some like sudo need to be called after init

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -492,7 +492,7 @@ impl StakeKeeper {
         unbonding_queue
             .iter_mut()
             .filter(|ub| &ub.validator == validator)
-            .for_each(|mut ub| {
+            .for_each(|ub| {
                 ub.amount = ub.amount * remaining_percentage;
             });
         UNBONDING_QUEUE.save(staking_storage, &unbonding_queue)?;


### PR DESCRIPTION
This is useful in testing. It's common to run a complicated setup procedure to build an app state, then to run different tests on that app. Rather that constantly rebuilding the state this allows you to clone it around.

It seems that perhaps other useful derives are missing as well (Debug being an obvious one). Though I don't immediately have a use case for that.