### PR TITLE
feat(app): add Stargate extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod ibc;
 mod module;
 mod prefixed_storage;
 mod staking;
+mod stargate;
 mod test_helpers;
 mod transactions;
 mod wasm;
@@ -35,4 +36,5 @@ pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
+pub use crate::stargate::{Stargate, StargateMsg, StargateQuery};
 pub use crate::wasm::{AddressGenerator, Wasm, WasmKeeper, WasmSudo};

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -994,6 +994,7 @@ mod test {
 
     use super::*;
 
+    use crate::stargate::{StargateMsg, StargateQuery};
     use cosmwasm_std::{
         from_slice,
         testing::{mock_env, MockApi, MockStorage},
@@ -1009,6 +1010,7 @@ mod test {
         DistributionKeeper,
         FailingModule<IbcMsg, IbcQuery, Empty>,
         FailingModule<GovMsg, Empty, Empty>,
+        FailingModule<StargateMsg, StargateQuery, Empty>,
     >;
 
     fn mock_router() -> BasicRouter {
@@ -1020,6 +1022,7 @@ mod test {
             distribution: DistributionKeeper::new(),
             ibc: FailingModule::new(),
             gov: FailingModule::new(),
+            stargate: FailingModule::new(),
         }
     }
 

--- a/src/stargate.rs
+++ b/src/stargate.rs
@@ -1,0 +1,162 @@
+use cosmwasm_std::{Binary, Empty};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{FailingModule, Module};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct StargateMsg {
+    pub type_url: String,
+    pub value: Binary,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct StargateQuery {
+    pub path: String,
+    pub data: Binary,
+}
+
+pub trait Stargate: Module<ExecT = StargateMsg, QueryT = StargateQuery, SudoT = Empty> {}
+
+impl Stargate for FailingModule<StargateMsg, StargateQuery, Empty> {}
+
+#[cfg(feature = "stargate")]
+#[cfg(test)]
+mod testing {
+    use std::fmt::Debug;
+
+    use anyhow::Result as AnyResult;
+    use cosmwasm_std::{
+        to_binary, Addr, Api, BlockInfo, CosmosMsg, CustomQuery, Deps, DepsMut, Env, MessageInfo,
+        Querier, QueryRequest, Response, StdResult, Storage,
+    };
+    use serde::de::DeserializeOwned;
+
+    use crate::app::no_init;
+    use crate::{AppResponse, BasicAppBuilder, ContractWrapper, CosmosRouter, Executor};
+
+    use super::*;
+
+    const RESPONSE_DATA: &str = "text";
+
+    #[derive(Serialize, Deserialize, JsonSchema)]
+    struct ExampleQueryResponse(String);
+
+    struct AcceptingModule;
+
+    impl Module for AcceptingModule {
+        type ExecT = StargateMsg;
+        type QueryT = StargateQuery;
+        type SudoT = Empty;
+
+        fn execute<ExecC, QueryC>(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+            _block: &BlockInfo,
+            _sender: Addr,
+            _msg: Self::ExecT,
+        ) -> AnyResult<AppResponse>
+        where
+            ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
+            QueryC: CustomQuery + DeserializeOwned + 'static,
+        {
+            Ok(AppResponse::default())
+        }
+
+        fn sudo<ExecC, QueryC>(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+            _block: &BlockInfo,
+            _msg: Self::SudoT,
+        ) -> AnyResult<AppResponse>
+        where
+            ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
+            QueryC: CustomQuery + DeserializeOwned + 'static,
+        {
+            unimplemented!("sudo is not implemented")
+        }
+
+        fn query(
+            &self,
+            _api: &dyn Api,
+            _storage: &dyn Storage,
+            _querier: &dyn Querier,
+            _block: &BlockInfo,
+            _request: Self::QueryT,
+        ) -> AnyResult<Binary> {
+            Ok(to_binary(&ExampleQueryResponse(RESPONSE_DATA.to_string()))?)
+        }
+    }
+
+    impl Stargate for AcceptingModule {}
+
+    #[test]
+    fn init_with_stargate() {
+        let mut app = BasicAppBuilder::new()
+            .with_stargate(AcceptingModule {})
+            .build(no_init);
+
+        let sender = Addr::unchecked("sender");
+        let msg = CosmosMsg::Stargate {
+            type_url: "/this.is.a.stargate.test".to_string(),
+            value: Default::default(),
+        };
+        app.execute(sender, msg).unwrap();
+
+        let req = QueryRequest::Stargate {
+            path: "/cosmos.bank.v1beta1.Query/TotalSupply".to_string(),
+            data: Default::default(),
+        };
+        let resp: ExampleQueryResponse = app.wrap().query(&req).unwrap();
+        assert_eq!(resp.0, RESPONSE_DATA)
+    }
+
+    #[test]
+    fn test_contract_producing_sgate_msgs() {
+        fn execute(deps: DepsMut, _: Env, _: MessageInfo, _: Empty) -> StdResult<Response> {
+            let res: ExampleQueryResponse = deps.querier.query(&QueryRequest::Stargate {
+                path: "/cosmos.bank.v1beta1.Query/TotalSupply".to_string(),
+                data: Default::default(),
+            })?;
+            Ok(Response::new().add_message(CosmosMsg::Stargate {
+                type_url: "/this.is.a.stargate.test".to_string(),
+                value: to_binary(&res.0)?,
+            }))
+        }
+        fn query(deps: Deps, _: Env, _: Empty) -> StdResult<Binary> {
+            let res: ExampleQueryResponse = deps.querier.query(&QueryRequest::Stargate {
+                path: "/cosmos.bank.v1beta1.Query/TotalSupply".to_string(),
+                data: Default::default(),
+            })?;
+            to_binary(&res.0)
+        }
+        let contract = Box::new(ContractWrapper::new(execute, execute, query));
+
+        let mut app = BasicAppBuilder::new()
+            .with_stargate(AcceptingModule {})
+            .build(no_init);
+
+        let code_id = app.store_code(contract);
+        let sender = Addr::unchecked("sender");
+        let contract_addr = app
+            .instantiate_contract(code_id, sender.clone(), &Empty {}, &[], "contract", None)
+            .unwrap();
+
+        // Stargate message produced by contract should be accepted
+        app.execute_contract(sender, contract_addr.clone(), &Empty {}, &[])
+            .unwrap();
+
+        // Contract just simply forwards the query response data
+        let resp: String = app
+            .wrap()
+            .query_wasm_smart(contract_addr, &Empty {})
+            .unwrap();
+        assert_eq!(resp, RESPONSE_DATA);
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1025,6 +1025,7 @@ mod test {
     use crate::bank::BankKeeper;
     use crate::module::FailingModule;
     use crate::staking::{DistributionKeeper, StakeKeeper};
+    use crate::stargate::{StargateMsg, StargateQuery};
     use crate::test_helpers::contracts::{caller, error, payout};
     use crate::transactions::StorageTransaction;
 
@@ -1039,6 +1040,7 @@ mod test {
         DistributionKeeper,
         FailingModule<IbcMsg, IbcQuery, Empty>,
         FailingModule<GovMsg, Empty, Empty>,
+        FailingModule<StargateMsg, StargateQuery, Empty>,
     >;
 
     fn wasm_keeper() -> WasmKeeper<Empty, Empty> {
@@ -1054,6 +1056,7 @@ mod test {
             distribution: DistributionKeeper::new(),
             ibc: FailingModule::new(),
             gov: FailingModule::new(),
+            stargate: FailingModule::new(),
         }
     }
 


### PR DESCRIPTION
### Add Stargate Module in App

This feature has been requested multiple times [1](https://github.com/CosmWasm/cw-multi-test/issues/40), [2](https://github.com/CosmWasm/cw-multi-test/issues/4).

The proposal is to introduce Stargate module within the default App, enabling developers to replace it with a customized Stargate module in AppBuilder. This enhancement will simplify the testing of multi-stage contract executions that generate Stargate messages and perform Stargate queries.

While some CosmWasm-enabled chains are transitioning their testing to test-tube, it's important to highlight that it does not provide a comprehensive test coverage report. For sophisticated DeFi projects with substantial value at risk, achieving only 10% or even zero test coverage is a significant concern within the crypto space, in my opinion. This underscores the value of incorporating the functionality of cw-multitest.

This PR does not directly introduce Stargate functionality tied to a specific Cosmos SDK chain implementation. Instead, it provides flexibility for developers to implement their Stargate module independently (an example can be found in the tests within stargate.rs).