### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,11 +247,10 @@ dependencies = [
  "cw-utils",
  "derivative",
  "ecdsa",
- "itertools 0.11.0",
+ "itertools",
  "prost",
  "schemars",
  "serde",
- "serde_json",
  "sha2 0.10.7",
  "thiserror",
 ]
@@ -346,9 +345,9 @@ checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -479,15 +478,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -578,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -588,15 +578,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,19 @@ cosmwasm_1_4 = ["cosmwasm_1_3", "cosmwasm-std/cosmwasm_1_4"]
 multitest_api_1_0 = []
 
 [dependencies]
-cw-utils = "1.0"
-cw-storage-plus = "1.1"
-cosmwasm-std = { version = "1.4", features = ["staking", "stargate"] }
-itertools = "0.11"
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-prost = "0.11"
-anyhow = "1.0"
-thiserror = "1.0"
-derivative = "2"
-sha2 = "0.10"
+cw-utils = "1.0.1"
+cw-storage-plus = "1.1.0"
+cosmwasm-std = { version = "1.4.0", features = ["staking", "stargate"] }
+itertools = "0.11.0"
+schemars = "0.8.13"
+serde = { version = "1.0.188", default-features = false, features = ["derive"] }
+prost = "0.12.0"
+anyhow = "1.0.75"
+thiserror = "1.0.48"
+derivative = "2.2.0"
+sha2 = "0.10.7"
 
 [dev-dependencies]
-# We don't use the following dependency directly,
-# we tighten the version so that builds with `-Zminimal-versions` work.
-serde_json = "1.0.105"
-ecdsa = "=0.16.7"
+# We don't use these dependencies directly,
+# we tighten versions that builds with `-Zminimal-versions` work.
+ecdsa = "0.16.8"


### PR DESCRIPTION
Updates dependencies of **cw-multi-test**, so that minimal number of not used dependencies have tightened version in Cargo.toml.

Currently it looks like only k256 has not tightly set ecdsa-core dependencies:
- https://github.com/RustCrypto/elliptic-curves/blob/672f234af9ba19056da8dbeab89d73b44ef5301e/k256/Cargo.toml#L26
- https://github.com/RustCrypto/elliptic-curves/blob/672f234af9ba19056da8dbeab89d73b44ef5301e/k256/Cargo.toml#L35

which lead to inconsistencies in types.

Thanks @chipshort, @webmaster128, and @uint for help in diagnosing this issue.