### PR TITLE
Removed multitest_api_1_0 feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,6 @@ cosmwasm_1_1 = ["cosmwasm-std/cosmwasm_1_1"]
 cosmwasm_1_2 = ["cosmwasm_1_1", "cosmwasm-std/cosmwasm_1_2"]
 cosmwasm_1_3 = ["cosmwasm_1_2", "cosmwasm-std/cosmwasm_1_3"]
 cosmwasm_1_4 = ["cosmwasm_1_3", "cosmwasm-std/cosmwasm_1_4"]
-# This experimental feature enables stable API to be released in version 1.0 of Multi Test.
-# We created this feature to provide as soon as possible a deeper insight into the Multi Test API 1.0.
-# Until version 1.0 of Multi Test is officially released, please consider this feature as experimental
-# and a subject to change at any time.
-# DO NOT enable this feature while testing production ready smart contracts.
-multitest_api_1_0 = []
 
 [dependencies]
 cw-utils = "1.0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    //TODO Remove the following block when publishing version 1.0 of Multi Test.
-    //     Remove this file also when the main function will be then empty.
-    {
-        #[cfg(feature = "multitest_api_1_0")]
-        println!("cargo:warning=Feature \"multitest_api_1_0\" is experimental, DO NOT enable it, unless you want to test Multi Test 1.0 API!");
-    }
-}

--- a/src/app.rs
+++ b/src/app.rs
@@ -697,18 +697,6 @@ where
 {
     /// Registers contract code (like uploading wasm bytecode on a chain),
     /// so it can later be used to instantiate a contract.
-    #[cfg(feature = "multitest_api_1_0")]
-    pub fn store_code(
-        &mut self,
-        creator: Addr,
-        code: Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>,
-    ) -> u64 {
-        self.init_modules(|router, _, _| router.wasm.store_code(creator, code))
-    }
-
-    /// Registers contract code (like uploading wasm bytecode on a chain),
-    /// so it can later be used to instantiate a contract.
-    #[cfg(not(feature = "multitest_api_1_0"))]
     pub fn store_code(&mut self, code: Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>) -> u64 {
         self.init_modules(|router, _, _| {
             router
@@ -718,8 +706,7 @@ where
     }
 
     /// Registers contract code (like [store_code](Self::store_code)),
-    /// takes the code creator address as an additional argument.
-    #[cfg(not(feature = "multitest_api_1_0"))]
+    /// but takes the address of the code creator as an additional argument.
     pub fn store_code_with_creator(
         &mut self,
         creator: Addr,
@@ -766,10 +753,7 @@ where
     /// let mut app = App::default();
     ///
     /// // store a new contract, save the code id
-    /// # #[cfg(not(feature = "multitest_api_1_0"))]
-    /// let code_id = app.store_code_with_creator(Addr::unchecked("creator"), echo::contract());
-    /// # #[cfg(feature = "multitest_api_1_0")]
-    /// # let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
+    /// let code_id = app.store_code(echo::contract());
     ///
     /// // duplicate the existing contract, duplicated contract has different code id
     /// assert_ne!(code_id, app.duplicate_code(code_id).unwrap());
@@ -1199,10 +1183,7 @@ mod test {
         let mut app = App::default();
 
         // store original contract code
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let original_code_id = app.store_code(payout::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let original_code_id = app.store_code(Addr::unchecked("creator"), payout::contract());
 
         // duplicate contract code
         let duplicate_code_id = app.duplicate_code(original_code_id).unwrap();
@@ -1304,10 +1285,7 @@ mod test {
         });
 
         // set up contract
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code_id = app.store_code(payout::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code_id = app.store_code(Addr::unchecked("creator"), payout::contract());
 
         let msg = payout::InstantiateMessage {
             payout: coin(5, "eth"),
@@ -1394,10 +1372,7 @@ mod test {
         });
 
         // set up payout contract
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let payout_id = app.store_code(payout::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let payout_id = app.store_code(Addr::unchecked("creator"), payout::contract());
 
         let msg = payout::InstantiateMessage {
             payout: coin(5, "eth"),
@@ -1414,10 +1389,7 @@ mod test {
             .unwrap();
 
         // set up reflect contract
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let reflect_id = app.store_code(reflect::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let reflect_id = app.store_code(Addr::unchecked("creator"), reflect::contract());
 
         let reflect_addr = app
             .instantiate_contract(reflect_id, owner, &Empty {}, &[], "Reflect", None)
@@ -1506,10 +1478,7 @@ mod test {
         });
 
         // set up reflect contract
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let reflect_id = app.store_code(reflect::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let reflect_id = app.store_code(Addr::unchecked("creator"), reflect::contract());
 
         let reflect_addr = app
             .instantiate_contract(
@@ -1603,10 +1572,7 @@ mod test {
                 .unwrap();
         });
 
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let payout_id = app.store_code(payout::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let payout_id = app.store_code(Addr::unchecked("creator"), payout::contract());
 
         let msg = payout::InstantiateMessage {
             payout: coin(5, "eth"),
@@ -1806,10 +1772,7 @@ mod test {
         });
 
         // set up reflect contract
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let reflect_id = app.store_code(reflect::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let reflect_id = app.store_code(Addr::unchecked("creator"), reflect::contract());
 
         let reflect_addr = app
             .instantiate_contract(
@@ -2010,10 +1973,7 @@ mod test {
                 .unwrap();
         });
 
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code_id = app.store_code(hackatom::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code_id = app.store_code(Addr::unchecked("creator"), hackatom::contract());
 
         let contract = app
             .instantiate_contract(
@@ -2064,10 +2024,7 @@ mod test {
         });
 
         // create a hackatom contract with some funds
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code_id = app.store_code(hackatom::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code_id = app.store_code(Addr::unchecked("creator"), hackatom::contract());
 
         let contract = app
             .instantiate_contract(
@@ -2131,10 +2088,7 @@ mod test {
         let mut app = App::default();
 
         // create a hackatom contract with some funds
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code_id = app.store_code(hackatom::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code_id = app.store_code(Addr::unchecked("creator"), hackatom::contract());
 
         let contract = app
             .instantiate_contract(
@@ -2233,10 +2187,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2263,10 +2214,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2299,10 +2247,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2330,10 +2275,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2361,10 +2303,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2404,20 +2343,14 @@ mod test {
             });
 
             // set up reflect contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let reflect_id = app.store_code(reflect::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let reflect_id = app.store_code(Addr::unchecked("creator"), reflect::contract());
 
             let reflect_addr = app
                 .instantiate_contract(reflect_id, owner.clone(), &Empty {}, &[], "Reflect", None)
                 .unwrap();
 
             // set up echo contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let echo_id = app.store_code(echo::custom_contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let echo_id = app.store_code(Addr::unchecked("creator"), echo::custom_contract());
 
             let echo_addr = app
                 .instantiate_contract(echo_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2460,10 +2393,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2511,10 +2441,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2547,10 +2474,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2598,10 +2522,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2653,10 +2574,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2687,10 +2605,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2721,10 +2636,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2754,10 +2666,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2787,10 +2696,7 @@ mod test {
 
             let owner = Addr::unchecked("owner");
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let contract = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "Echo", None)
@@ -2825,10 +2731,7 @@ mod test {
             let sender = Addr::unchecked("sender");
 
             // store contract's code
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code_with_creator(Addr::unchecked("creator"), echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             // initialize the contract
             let init_msg = to_binary(&Empty {}).unwrap();
@@ -2872,10 +2775,7 @@ mod test {
         fn query_existing_code_info() {
             use super::*;
             let mut app = App::default();
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code_with_creator(Addr::unchecked("creator"), echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
             let code_info_response = app.wrap().query_wasm_code_info(code_id).unwrap();
             assert_eq!(code_id, code_info_response.code_id);
             assert_eq!("creator", code_info_response.creator);
@@ -2916,10 +2816,7 @@ mod test {
                 .with_custom(custom_handler)
                 .build(no_init);
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let contract_id = app.store_code(echo::custom_contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let contract_id = app.store_code(Addr::unchecked("creator"), echo::custom_contract());
 
             let contract = app
                 .instantiate_contract(contract_id, owner, &Empty {}, &[], "Echo", None)
@@ -2966,10 +2863,7 @@ mod test {
             });
 
             // set up reflect contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(reflect::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), reflect::contract());
 
             let init_msg = to_binary(&Empty {}).unwrap();
             let msg = WasmMsg::Instantiate {
@@ -2999,10 +2893,7 @@ mod test {
             let mut app = BasicApp::new(|_, _, _| {});
 
             // set up echo contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let msg = echo::InitMessage::<Empty> {
                 data: Some("food".into()),
@@ -3031,10 +2922,7 @@ mod test {
             let mut app = BasicApp::new(|_, _, _| {});
 
             // set up echo contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let msg = echo::InitMessage::<Empty> {
                 data: Some("food".into()),
@@ -3086,10 +2974,7 @@ mod test {
             let mut app = BasicApp::new(|_, _, _| {});
 
             // set up reflect contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(echo::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), echo::contract());
 
             let echo_addr = app
                 .instantiate_contract(code_id, owner.clone(), &Empty {}, &[], "label", None)
@@ -3115,10 +3000,7 @@ mod test {
             let mut app = App::default();
 
             // set up contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(error::contract(false));
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), error::contract(false));
 
             let msg = Empty {};
             let err = app
@@ -3144,10 +3026,7 @@ mod test {
             let mut app = App::default();
 
             // set up contract
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let code_id = app.store_code(error::contract(true));
-            #[cfg(feature = "multitest_api_1_0")]
-            let code_id = app.store_code(Addr::unchecked("creator"), error::contract(true));
 
             let msg = Empty {};
             let contract_addr = app
@@ -3177,14 +3056,8 @@ mod test {
             let owner = Addr::unchecked("owner");
             let mut app = App::default();
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let error_code_id = app.store_code(error::contract(true));
-            #[cfg(feature = "multitest_api_1_0")]
-            let error_code_id = app.store_code(Addr::unchecked("creator"), error::contract(true));
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let caller_code_id = app.store_code(caller::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let caller_code_id = app.store_code(Addr::unchecked("creator"), caller::contract());
 
             // set up contracts
             let msg = Empty {};
@@ -3223,14 +3096,8 @@ mod test {
             let owner = Addr::unchecked("owner");
             let mut app = App::default();
 
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let error_code_id = app.store_code(error::contract(true));
-            #[cfg(feature = "multitest_api_1_0")]
-            let error_code_id = app.store_code(Addr::unchecked("creator"), error::contract(true));
-            #[cfg(not(feature = "multitest_api_1_0"))]
             let caller_code_id = app.store_code(caller::contract());
-            #[cfg(feature = "multitest_api_1_0")]
-            let caller_code_id = app.store_code(Addr::unchecked("creator"), caller::contract());
 
             // set up contracts
             let msg = Empty {};

--- a/src/gov.rs
+++ b/src/gov.rs
@@ -81,10 +81,7 @@ mod test {
     #[test]
     fn default_gov() {
         let mut app = App::default();
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code = app.store_code(stargate::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code = app.store_code(Addr::unchecked("creator"), stargate::contract());
         let contract = app
             .instantiate_contract(
                 code,
@@ -105,10 +102,7 @@ mod test {
         let mut app = AppBuilder::new()
             .with_gov(AcceptingModule)
             .build(|_, _, _| ());
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code = app.store_code(stargate::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code = app.store_code(Addr::unchecked("creator"), stargate::contract());
         let contract = app
             .instantiate_contract(
                 code,

--- a/src/ibc.rs
+++ b/src/ibc.rs
@@ -81,10 +81,7 @@ mod test {
     #[test]
     fn default_ibc() {
         let mut app = App::default();
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code = app.store_code(stargate::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code = app.store_code(Addr::unchecked("creator"), stargate::contract());
         let contract = app
             .instantiate_contract(
                 code,
@@ -105,10 +102,7 @@ mod test {
         let mut app = AppBuilder::new()
             .with_ibc(IbcAcceptingModule)
             .build(|_, _, _| ());
-        #[cfg(not(feature = "multitest_api_1_0"))]
         let code = app.store_code(stargate::contract());
-        #[cfg(feature = "multitest_api_1_0")]
-        let code = app.store_code(Addr::unchecked("creator"), stargate::contract());
         let contract = app
             .instantiate_contract(
                 code,


### PR DESCRIPTION
Using a dedicated feature to plan API changes in future version is more cumbersome than keeping issues to be implemented before releasing planned version. As an example, see: #69 and #70.