### PR TITLE
Extended `Wasm` trait, tested `AppBuilder::with_wasm`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -173,7 +173,8 @@ pub type BasicAppBuilder<ExecC, QueryC> = AppBuilder<
     FailingModule<GovMsg, Empty, Empty>,
 >;
 
-/// Utility to build App in stages. If particular items wont be set, defaults would be used
+/// Utility to build [App] in stages. If particular items/properties are not explicitly set,
+/// then default values are used.
 pub struct AppBuilder<Bank, Api, Storage, Custom, Wasm, Staking, Distr, Ibc, Gov> {
     api: Api,
     block: BlockInfo,
@@ -275,15 +276,11 @@ where
     CustomT: Module,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
 {
-    /// Overwrites default wasm executor.
+    /// Overwrites the default wasm executor.
     ///
     /// At this point it is needed that new wasm implements some `Wasm` trait, but it doesn't need
     /// to be bound to Bank or Custom yet - as those may change. The cross-components validation is
     /// done on final building.
-    ///
-    /// Also it is possible to completely abandon trait bounding here which would not be bad idea,
-    /// however it might make the message on build creepy in many cases, so as for properly build
-    /// `App` we always want `Wasm` to be `Wasm`, some checks are done early.
     pub fn with_wasm<NewWasm: Wasm<CustomT::ExecT, CustomT::QueryT>>(
         self,
         wasm: NewWasm,
@@ -315,7 +312,7 @@ where
         }
     }
 
-    /// Overwrites default bank interface
+    /// Overwrites the default bank interface.
     pub fn with_bank<NewBank: Bank>(
         self,
         bank: NewBank,
@@ -347,7 +344,7 @@ where
         }
     }
 
-    /// Overwrites default api interface
+    /// Overwrites the default api interface.
     pub fn with_api<NewApi: Api>(
         self,
         api: NewApi,
@@ -379,7 +376,7 @@ where
         }
     }
 
-    /// Overwrites default storage interface
+    /// Overwrites the default storage interface.
     pub fn with_storage<NewStorage: Storage>(
         self,
         storage: NewStorage,
@@ -411,15 +408,11 @@ where
         }
     }
 
-    /// Overwrites default custom messages handler
+    /// Overwrites the default custom messages handler.
     ///
     /// At this point it is needed that new custom implements some `Module` trait, but it doesn't need
     /// to be bound to ExecC or QueryC yet - as those may change. The cross-components validation is
     /// done on final building.
-    ///
-    /// Also it is possible to completely abandon trait bounding here which would not be bad idea,
-    /// however it might make the message on build creepy in many cases, so as for properly build
-    /// `App` we always want `Wasm` to be `Wasm`, some checks are done early.
     pub fn with_custom<NewCustom: Module>(
         self,
         custom: NewCustom,
@@ -451,7 +444,7 @@ where
         }
     }
 
-    /// Overwrites default bank interface
+    /// Overwrites the default staking interface.
     pub fn with_staking<NewStaking: Staking>(
         self,
         staking: NewStaking,
@@ -483,7 +476,7 @@ where
         }
     }
 
-    /// Overwrites default distribution interface
+    /// Overwrites the default distribution interface.
     pub fn with_distribution<NewDistribution: Distribution>(
         self,
         distribution: NewDistribution,
@@ -516,10 +509,13 @@ where
         }
     }
 
-    /// Overwrites default ibc interface.
+    /// Overwrites the default ibc interface.
     ///
-    /// If you wish to simply ignore/drop all returned IBC Messages, you can use the `IbcAcceptingModule` type.
-    ///     builder.with_ibc(IbcAcceptingModule::new())
+    /// If you wish to simply ignore/drop all returned IBC Messages,
+    /// you can use the `IbcAcceptingModule` type:
+    /// ```text
+    /// builder.with_ibc(IbcAcceptingModule::new())
+    /// ```
     pub fn with_ibc<NewIbc: Ibc>(
         self,
         ibc: NewIbc,
@@ -551,7 +547,7 @@ where
         }
     }
 
-    /// Overwrites default gov interface
+    /// Overwrites the default gov interface.
     pub fn with_gov<NewGov: Gov>(
         self,
         gov: NewGov,
@@ -583,14 +579,14 @@ where
         }
     }
 
-    /// Overwrites default initial block
+    /// Overwrites the initial block.
     pub fn with_block(mut self, block: BlockInfo) -> Self {
         self.block = block;
         self
     }
 
     /// Builds final `App`. At this point all components type have to be properly related to each
-    /// other. If there are some generics related compilation error make sure, that all components
+    /// other. If there are some generics related compilation errors, make sure that all components
     /// are properly relating to each other.
     pub fn build<F>(
         self,

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,6 +271,9 @@ where
 
 impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
     AppBuilder<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
+where
+    CustomT: Module,
+    WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
 {
     /// Overwrites default wasm executor.
     ///
@@ -281,7 +284,7 @@ impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
     /// Also it is possible to completely abandon trait bounding here which would not be bad idea,
     /// however it might make the message on build creepy in many cases, so as for properly build
     /// `App` we always want `Wasm` to be `Wasm`, some checks are done early.
-    pub fn with_wasm<C: Module, NewWasm: Wasm<C::ExecT, C::QueryT>>(
+    pub fn with_wasm<NewWasm: Wasm<CustomT::ExecT, CustomT::QueryT>>(
         self,
         wasm: NewWasm,
     ) -> AppBuilder<BankT, ApiT, StorageT, CustomT, NewWasm, StakingT, DistrT, IbcT, GovT> {
@@ -756,12 +759,12 @@ where
         self.init_modules(|router, _, _| router.wasm.duplicate_code(code_id))
     }
 
-    /// This allows to get `ContractData` for specific contract
+    /// Returns `ContractData` for the contract with specified address.
     pub fn contract_data(&self, address: &Addr) -> AnyResult<ContractData> {
         self.read_module(|router, _, storage| router.wasm.contract_data(storage, address))
     }
 
-    /// This gets a raw state dump of all key-values held by a given contract
+    /// Returns a raw state dump of all key-values held by a contract with specified address.
     pub fn dump_wasm_raw(&self, address: &Addr) -> Vec<Record> {
         self.read_module(|router, _, storage| router.wasm.dump_wasm_raw(storage, address))
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -668,23 +668,14 @@ where
 
 // Helper functions to call some custom WasmKeeper logic.
 // They show how we can easily add such calls to other custom keepers (CustomT, StakingT, etc)
-impl<BankT, ApiT, StorageT, CustomT, StakingT, DistrT, IbcT, GovT>
-    App<
-        BankT,
-        ApiT,
-        StorageT,
-        CustomT,
-        WasmKeeper<CustomT::ExecT, CustomT::QueryT>,
-        StakingT,
-        DistrT,
-        IbcT,
-        GovT,
-    >
+impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
+    App<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
     BankT: Bank,
     ApiT: Api,
     StorageT: Storage,
     CustomT: Module,
+    WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
     StakingT: Staking,
     DistrT: Distribution,
     IbcT: Ibc,
@@ -767,7 +758,7 @@ where
 
     /// This allows to get `ContractData` for specific contract
     pub fn contract_data(&self, address: &Addr) -> AnyResult<ContractData> {
-        self.read_module(|router, _, storage| router.wasm.load_contract(storage, address))
+        self.read_module(|router, _, storage| router.wasm.contract_data(storage, address))
     }
 
     /// This gets a raw state dump of all key-values held by a given contract

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::{
 
 use anyhow::{anyhow, bail, Result as AnyResult};
 
-/// Interface to call into a [Contract].
+/// Interface to call into a `Contract`.
 pub trait Contract<T, Q = Empty>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,4 +36,4 @@ pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
-pub use crate::wasm::{AddressGenerator, Wasm, WasmKeeper, WasmSudo};
+pub use crate::wasm::{AddressGenerator, ContractData, Wasm, WasmKeeper, WasmSudo};

--- a/src/module.rs
+++ b/src/module.rs
@@ -8,6 +8,7 @@ use crate::AppResponse;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
+/// Interface of the module.
 pub trait Module {
     type ExecT;
     type QueryT;

--- a/tests/app_builder/mod.rs
+++ b/tests/app_builder/mod.rs
@@ -1,0 +1,1 @@
+mod with_wasm;

--- a/tests/app_builder/with_wasm.rs
+++ b/tests/app_builder/with_wasm.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     Response, StdError, Storage, SubMsg, WasmMsg, WasmQuery,
 };
 use cw_multi_test::{
-    AppBuilder, AppResponse, Contract, ContractData, ContractWrapper, CosmosRouter, Module, Wasm,
+    AppBuilder, AppResponse, Contract, ContractData, ContractWrapper, CosmosRouter, Wasm,
 };
 use schemars::JsonSchema;
 use std::fmt::Debug;
@@ -59,50 +59,6 @@ fn building_app_with_custom_wasm_should_work() {
     impl<ExecT, QueryT> Default for MyWasm<ExecT, QueryT> {
         fn default() -> Self {
             Self(PhantomData)
-        }
-    }
-
-    impl<Exec, Query> Module for MyWasm<Exec, Query>
-    where
-        Exec: Debug,
-        Query: Debug,
-    {
-        type ExecT = Exec;
-        type QueryT = Query;
-        type SudoT = Empty;
-
-        fn execute<ExecC, QueryC>(
-            &self,
-            _api: &dyn Api,
-            _storage: &mut dyn Storage,
-            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-            _block: &BlockInfo,
-            _sender: Addr,
-            _msg: Self::ExecT,
-        ) -> AnyResult<AppResponse> {
-            todo!()
-        }
-
-        fn sudo<ExecC, QueryC>(
-            &self,
-            _api: &dyn Api,
-            _storage: &mut dyn Storage,
-            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-            _block: &BlockInfo,
-            _msg: Self::SudoT,
-        ) -> AnyResult<AppResponse> {
-            todo!()
-        }
-
-        fn query(
-            &self,
-            _api: &dyn Api,
-            _storage: &dyn Storage,
-            _querier: &dyn Querier,
-            _block: &BlockInfo,
-            _request: Self::QueryT,
-        ) -> AnyResult<Binary> {
-            todo!()
         }
     }
 
@@ -164,10 +120,7 @@ fn building_app_with_custom_wasm_should_work() {
     }
 
     let app_builder = AppBuilder::default();
-    let mut app = app_builder
-        .with_wasm::<MyWasm<Empty, Empty>, MyWasm<Empty, Empty>>(MyWasm::default())
-        .build(|_, _, _| {});
-
+    let mut app = app_builder.with_wasm(MyWasm::default()).build(|_, _, _| {});
     let code_id = app.store_code(contracts::caller::contract());
     assert_eq!(154, code_id);
 }

--- a/tests/app_builder/with_wasm.rs
+++ b/tests/app_builder/with_wasm.rs
@@ -1,0 +1,173 @@
+use anyhow::Result as AnyResult;
+use cosmwasm_std::{
+    Addr, Api, Binary, BlockInfo, Deps, DepsMut, Empty, Env, MessageInfo, Querier, Record,
+    Response, StdError, Storage, SubMsg, WasmMsg, WasmQuery,
+};
+use cw_multi_test::{
+    AppBuilder, AppResponse, Contract, ContractData, ContractWrapper, CosmosRouter, Module, Wasm,
+};
+use schemars::JsonSchema;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+mod contracts {
+    use super::*;
+
+    pub mod caller {
+        use super::*;
+
+        fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> Result<Response, StdError> {
+            Ok(Response::default())
+        }
+
+        fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            msg: WasmMsg,
+        ) -> Result<Response, StdError> {
+            let message = SubMsg::new(msg);
+
+            Ok(Response::new().add_submessage(message))
+        }
+
+        fn query(_deps: Deps, _env: Env, _msg: Empty) -> Result<Binary, StdError> {
+            Err(StdError::generic_err(
+                "query not implemented for the `caller` contract",
+            ))
+        }
+
+        pub fn contract<C>() -> Box<dyn Contract<C>>
+        where
+            C: Clone + Debug + PartialEq + JsonSchema + 'static,
+        {
+            let contract = ContractWrapper::new_with_empty(execute, instantiate, query);
+            Box::new(contract)
+        }
+    }
+}
+
+#[test]
+fn building_app_with_custom_wasm_should_work() {
+    struct MyWasm<ExecT, QueryT>(PhantomData<(ExecT, QueryT)>);
+
+    impl<ExecT, QueryT> Default for MyWasm<ExecT, QueryT> {
+        fn default() -> Self {
+            Self(PhantomData)
+        }
+    }
+
+    impl<Exec, Query> Module for MyWasm<Exec, Query>
+    where
+        Exec: Debug,
+        Query: Debug,
+    {
+        type ExecT = Exec;
+        type QueryT = Query;
+        type SudoT = Empty;
+
+        fn execute<ExecC, QueryC>(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+            _block: &BlockInfo,
+            _sender: Addr,
+            _msg: Self::ExecT,
+        ) -> AnyResult<AppResponse> {
+            todo!()
+        }
+
+        fn sudo<ExecC, QueryC>(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+            _block: &BlockInfo,
+            _msg: Self::SudoT,
+        ) -> AnyResult<AppResponse> {
+            todo!()
+        }
+
+        fn query(
+            &self,
+            _api: &dyn Api,
+            _storage: &dyn Storage,
+            _querier: &dyn Querier,
+            _block: &BlockInfo,
+            _request: Self::QueryT,
+        ) -> AnyResult<Binary> {
+            todo!()
+        }
+    }
+
+    impl<ExecT, QueryT> Wasm<ExecT, QueryT> for MyWasm<ExecT, QueryT> {
+        fn query(
+            &self,
+            _api: &dyn Api,
+            _storage: &dyn Storage,
+            _querier: &dyn Querier,
+            _block: &BlockInfo,
+            _request: WasmQuery,
+        ) -> AnyResult<Binary> {
+            todo!()
+        }
+
+        fn execute(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecT, QueryC = QueryT>,
+            _block: &BlockInfo,
+            _sender: Addr,
+            _msg: WasmMsg,
+        ) -> AnyResult<AppResponse> {
+            todo!()
+        }
+
+        fn sudo(
+            &self,
+            _api: &dyn Api,
+            _contract_addr: Addr,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecT, QueryC = QueryT>,
+            _block: &BlockInfo,
+            _msg: Binary,
+        ) -> AnyResult<AppResponse> {
+            todo!()
+        }
+
+        fn store_code(&mut self, _creator: Addr, _code: Box<dyn Contract<ExecT, QueryT>>) -> u64 {
+            154
+        }
+
+        fn duplicate_code(&mut self, _code_id: u64) -> AnyResult<u64> {
+            todo!()
+        }
+
+        fn contract_data(
+            &self,
+            _storage: &dyn Storage,
+            _address: &Addr,
+        ) -> AnyResult<ContractData> {
+            todo!()
+        }
+
+        fn dump_wasm_raw(&self, _storage: &dyn Storage, _address: &Addr) -> Vec<Record> {
+            todo!()
+        }
+    }
+
+    let app_builder = AppBuilder::default();
+    let mut app = app_builder
+        .with_wasm::<MyWasm<Empty, Empty>, MyWasm<Empty, Empty>>(MyWasm::default())
+        .build(|_, _, _| {});
+
+    let code_id = app.store_code(contracts::caller::contract());
+    assert_eq!(154, code_id);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+mod app_builder;


### PR DESCRIPTION
# Scope of the change

## Extended `Wasm` trait with functions called on `WasmKeeper` from `App`

Providing _shortcuts_ to `Wasm` module from `App` has bounded our internal implementation of `Wasm` named `WasmKeeper` to `App`. To remove these bounds and to allow users to provide their own implementation of `Wasm` interface to `AppBuilder::with_wasm`, the `Wasm` interface has been extended with additional functions called from `App`, i.e:
- store_code,
- duplicate_code,
- contract_data,
- dump_wasm_raw

## Added integration test for `AppBuilder::with_wasm`

Added a test with example how to provide own implementation of `Wasm` interface to `AppBuilder::with_wasm` function.