### PR TITLE
Custom checksum generator

### DIFF
--- a/src/checksums.rs
+++ b/src/checksums.rs
@@ -1,0 +1,27 @@
+//! # Implementation of the interface to custom checksum generator
+
+use cosmwasm_std::{Addr, HexBinary};
+use sha2::{Digest, Sha256};
+
+/// An interface to call custom checksum generator for contract's code.
+///
+/// This trait defines a method to calculate checksum based on
+/// the creator's address and a unique code identifier.
+pub trait ChecksumGenerator {
+    /// Calculates the checksum for a given contract's code creator
+    /// and code identifier. Returns a hexadecimal binary representation
+    /// of the calculated checksum. There are no assumptions about
+    /// the length of the calculated checksum.
+    fn checksum(&self, creator: Addr, code_id: u64) -> HexBinary;
+}
+
+/// Default checksum generator implementation.
+pub struct SimpleChecksumGenerator;
+
+impl ChecksumGenerator for SimpleChecksumGenerator {
+    /// Calculates the checksum based on code identifier. The resulting
+    /// checksum is 32-byte length SHA2 digest.
+    fn checksum(&self, _creator: Addr, code_id: u64) -> HexBinary {
+        HexBinary::from(Sha256::digest(format!("contract code {}", code_id)).to_vec())
+    }
+}

--- a/src/checksums.rs
+++ b/src/checksums.rs
@@ -12,7 +12,7 @@ pub trait ChecksumGenerator {
     /// and code identifier. Returns a hexadecimal binary representation
     /// of the calculated checksum. There are no assumptions about
     /// the length of the calculated checksum.
-    fn checksum(&self, creator: Addr, code_id: u64) -> HexBinary;
+    fn checksum(&self, creator: &Addr, code_id: u64) -> HexBinary;
 }
 
 /// Default checksum generator implementation.
@@ -21,7 +21,7 @@ pub struct SimpleChecksumGenerator;
 impl ChecksumGenerator for SimpleChecksumGenerator {
     /// Calculates the checksum based on code identifier. The resulting
     /// checksum is 32-byte length SHA2 digest.
-    fn checksum(&self, _creator: Addr, code_id: u64) -> HexBinary {
+    fn checksum(&self, _creator: &Addr, code_id: u64) -> HexBinary {
         HexBinary::from(Sha256::digest(format!("contract code {}", code_id)).to_vec())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 mod app;
 mod app_builder;
 mod bank;
+mod checksums;
 #[allow(clippy::type_complexity)]
 mod contracts;
 pub mod custom_handler;
@@ -27,6 +28,7 @@ mod wasm;
 pub use crate::app::{custom_app, next_block, App, BasicApp, CosmosRouter, Router, SudoMsg};
 pub use crate::app_builder::{AppBuilder, BasicAppBuilder};
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
+pub use crate::checksums::ChecksumGenerator;
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::gov::Gov;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -244,7 +244,7 @@ where
         let code_base_id = self.code_base.len();
         self.code_base.push(code);
         let code_id = (self.code_data.len() + 1) as u64;
-        let checksum = self.checksum_generator.checksum(creator.clone(), code_id);
+        let checksum = self.checksum_generator.checksum(&creator, code_id);
         self.code_data.push(CodeData {
             creator,
             checksum,
@@ -385,7 +385,7 @@ where
         }
     }
 
-    pub fn new_with_checksum_generator(
+    pub fn with_checksum_generator(
         mut self,
         checksum_generator: impl ChecksumGenerator + 'static,
     ) -> Self {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,5 @@
 use crate::app::{CosmosRouter, RouterQuerier};
+use crate::checksums::{ChecksumGenerator, SimpleChecksumGenerator};
 use crate::contracts::Contract;
 use crate::error::{bail, AnyContext, AnyError, AnyResult, Error};
 use crate::executor::AppResponse;
@@ -16,7 +17,6 @@ use prost::Message;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::borrow::Borrow;
 use std::fmt::Debug;
 
@@ -121,8 +121,10 @@ pub struct WasmKeeper<ExecC, QueryC> {
     code_base: Vec<Box<dyn Contract<ExecC, QueryC>>>,
     /// Code data with code base identifier and additional attributes.  
     code_data: Vec<CodeData>,
-    /// Contract address generator.
-    generator: Box<dyn AddressGenerator>,
+    /// Contract's address generator.
+    address_generator: Box<dyn AddressGenerator>,
+    /// Contract's code checksum generator.
+    checksum_generator: Box<dyn ChecksumGenerator>,
     /// Just markers to make type elision fork when using it as `Wasm` trait
     _p: std::marker::PhantomData<QueryC>,
 }
@@ -153,7 +155,8 @@ impl<ExecC, QueryC> Default for WasmKeeper<ExecC, QueryC> {
         Self {
             code_base: Vec::default(),
             code_data: Vec::default(),
-            generator: Box::new(SimpleAddressGenerator()),
+            address_generator: Box::new(SimpleAddressGenerator()),
+            checksum_generator: Box::new(SimpleChecksumGenerator),
             _p: std::marker::PhantomData,
         }
     }
@@ -240,15 +243,14 @@ where
     fn store_code(&mut self, creator: Addr, code: Box<dyn Contract<ExecC, QueryC>>) -> u64 {
         let code_base_id = self.code_base.len();
         self.code_base.push(code);
-        let code_id = self.code_data.len() + 1;
-        let checksum =
-            HexBinary::from(Sha256::digest(format!("contract code {}", code_id)).to_vec());
+        let code_id = (self.code_data.len() + 1) as u64;
+        let checksum = self.checksum_generator.checksum(creator.clone(), code_id);
         self.code_data.push(CodeData {
             creator,
             checksum,
             code_base_id,
         });
-        code_id as u64
+        code_id
     }
 
     /// Duplicates the contract's code with specified identifier.
@@ -374,11 +376,21 @@ where
         Self::default()
     }
 
-    pub fn new_with_custom_address_generator(generator: impl AddressGenerator + 'static) -> Self {
+    pub fn new_with_custom_address_generator(
+        address_generator: impl AddressGenerator + 'static,
+    ) -> Self {
         Self {
-            generator: Box::new(generator),
+            address_generator: Box::new(address_generator),
             ..Default::default()
         }
+    }
+
+    pub fn new_with_checksum_generator(
+        mut self,
+        checksum_generator: impl ChecksumGenerator + 'static,
+    ) -> Self {
+        self.checksum_generator = Box::new(checksum_generator);
+        self
     }
 
     pub fn query_smart(
@@ -828,7 +840,7 @@ where
             bail!("Cannot init contract with unregistered code id");
         }
 
-        let addr = self.generator.next_address(storage);
+        let addr = self.address_generator.next_address(storage);
 
         let info = ContractData {
             code_id,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,2 +1,66 @@
+use cw_storage_plus::Item;
+use serde::{Deserialize, Serialize};
+
 mod test_app_builder;
 mod test_module;
+mod test_wasm;
+
+const COUNTER: Item<u64> = Item::new("count");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CounterQueryMsg {
+    Counter {},
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CounterResponseMsg {
+    value: u64,
+}
+
+mod test_contracts {
+    use super::*;
+
+    pub mod counter {
+        use super::*;
+        use cosmwasm_std::{
+            to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError, WasmMsg,
+        };
+        use cw_multi_test::{Contract, ContractWrapper};
+
+        fn instantiate(
+            deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> Result<Response, StdError> {
+            COUNTER.save(deps.storage, &1).unwrap();
+            Ok(Response::default())
+        }
+
+        fn execute(
+            deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: WasmMsg,
+        ) -> Result<Response, StdError> {
+            if let Some(mut counter) = COUNTER.may_load(deps.storage).unwrap() {
+                counter += 1;
+                COUNTER.save(deps.storage, &counter).unwrap();
+            }
+            Ok(Response::default())
+        }
+
+        fn query(deps: Deps, _env: Env, msg: CounterQueryMsg) -> Result<Binary, StdError> {
+            match msg {
+                CounterQueryMsg::Counter { .. } => Ok(to_binary(&CounterResponseMsg {
+                    value: COUNTER.may_load(deps.storage).unwrap().unwrap(),
+                })?),
+            }
+        }
+
+        pub fn contract() -> Box<dyn Contract<Empty>> {
+            Box::new(ContractWrapper::new_with_empty(execute, instantiate, query))
+        }
+    }
+}

--- a/tests/test_app_builder/mod.rs
+++ b/tests/test_app_builder/mod.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::{Addr, Api, Binary, BlockInfo, CustomQuery, Querier, Storage};
 use cw_multi_test::error::{bail, AnyResult};
 use cw_multi_test::{AppResponse, CosmosRouter, Module};
-use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -15,66 +13,6 @@ mod test_with_distribution;
 mod test_with_staking;
 mod test_with_storage;
 mod test_with_wasm;
-
-const COUNTER: Item<u64> = Item::new("count");
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum CounterQueryMsg {
-    Counter {},
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CounterResponseMsg {
-    value: u64,
-}
-
-mod contracts {
-    use super::*;
-
-    pub mod counter {
-        use super::*;
-        use cosmwasm_std::{
-            to_binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError, WasmMsg,
-        };
-        use cw_multi_test::{Contract, ContractWrapper};
-
-        fn instantiate(
-            deps: DepsMut,
-            _env: Env,
-            _info: MessageInfo,
-            _msg: Empty,
-        ) -> Result<Response, StdError> {
-            COUNTER.save(deps.storage, &1).unwrap();
-            Ok(Response::default())
-        }
-
-        fn execute(
-            deps: DepsMut,
-            _env: Env,
-            _info: MessageInfo,
-            _msg: WasmMsg,
-        ) -> Result<Response, StdError> {
-            if let Some(mut counter) = COUNTER.may_load(deps.storage).unwrap() {
-                counter += 1;
-                COUNTER.save(deps.storage, &counter).unwrap();
-            }
-            Ok(Response::default())
-        }
-
-        fn query(deps: Deps, _env: Env, msg: CounterQueryMsg) -> Result<Binary, StdError> {
-            match msg {
-                CounterQueryMsg::Counter { .. } => Ok(to_binary(&CounterResponseMsg {
-                    value: COUNTER.may_load(deps.storage).unwrap().unwrap(),
-                })?),
-            }
-        }
-
-        pub fn contract() -> Box<dyn Contract<Empty>> {
-            Box::new(ContractWrapper::new_with_empty(execute, instantiate, query))
-        }
-    }
-}
 
 struct MyKeeper<ExecT, QueryT, SudoT>(
     PhantomData<(ExecT, QueryT, SudoT)>,

--- a/tests/test_app_builder/test_with_storage.rs
+++ b/tests/test_app_builder/test_with_storage.rs
@@ -1,4 +1,4 @@
-use crate::test_app_builder::{contracts, CounterQueryMsg, CounterResponseMsg};
+use crate::{test_contracts, CounterQueryMsg, CounterResponseMsg};
 use cosmwasm_std::{to_binary, Addr, Empty, Order, Record, Storage, WasmMsg};
 use cw_multi_test::{AppBuilder, Executor};
 use std::collections::BTreeMap;
@@ -47,7 +47,7 @@ fn building_app_with_custom_storage_should_work() {
         .build(|_, _, _| {});
 
     // store a contract code
-    let code_id = app.store_code(contracts::counter::contract());
+    let code_id = app.store_code(test_contracts::counter::contract());
 
     // instantiate contract, this initializes a counter with value 1
     let contract_addr = app

--- a/tests/test_app_builder/test_with_wasm.rs
+++ b/tests/test_app_builder/test_with_wasm.rs
@@ -1,4 +1,5 @@
-use crate::test_app_builder::{contracts, MyKeeper};
+use crate::test_app_builder::MyKeeper;
+use crate::test_contracts;
 use cosmwasm_std::{
     Addr, Api, Binary, BlockInfo, Empty, Querier, Record, Storage, WasmMsg, WasmQuery,
 };
@@ -89,7 +90,7 @@ fn building_app_with_custom_wasm_should_work() {
     let contract_addr = Addr::unchecked("contract");
 
     // calling store_code should return value defined in custom keeper
-    assert_eq!(CODE_ID, app.store_code(contracts::counter::contract()));
+    assert_eq!(CODE_ID, app.store_code(test_contracts::counter::contract()));
 
     // calling duplicate_code should return error defined in custom keeper
     assert_eq!(

--- a/tests/test_wasm/mod.rs
+++ b/tests/test_wasm/mod.rs
@@ -1,0 +1,1 @@
+mod test_with_checksum_gen;

--- a/tests/test_wasm/test_with_checksum_gen.rs
+++ b/tests/test_wasm/test_with_checksum_gen.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "cosmwasm_1_2")]
+
+use crate::test_contracts;
+use cosmwasm_std::{Addr, Empty, HexBinary};
+use cw_multi_test::{App, AppBuilder, ChecksumGenerator, WasmKeeper};
+
+#[test]
+fn default_checksum_generator_should_work() {
+    // prepare default application with default wasm keeper
+    let mut app = App::default();
+
+    // store contract's code
+    let code_id = app.store_code_with_creator(
+        Addr::unchecked("creator"),
+        test_contracts::counter::contract(),
+    );
+
+    // get code info
+    let code_info_response = app.wrap().query_wasm_code_info(code_id).unwrap();
+
+    // this should be default checksum
+    assert_eq!(
+        code_info_response.checksum.to_hex(),
+        "27095b438f70aed35405149bc5e8dfa1d461f7cd9c25359807ad66dcc1396fc7"
+    );
+}
+
+struct MyChecksumGenerator;
+
+impl ChecksumGenerator for MyChecksumGenerator {
+    fn checksum(&self, _creator: Addr, _code_id: u64) -> HexBinary {
+        HexBinary::from_hex("c0ffee01c0ffee02c0ffee03c0ffee04c0ffee05c0ffee06c0ffee07c0ffee08")
+            .unwrap()
+    }
+}
+
+#[test]
+fn custom_checksum_generator_should_work() {
+    // prepare wasm keeper with custom checksum generator
+    let wasm_keeper: WasmKeeper<Empty, Empty> =
+        WasmKeeper::default().new_with_checksum_generator(MyChecksumGenerator);
+
+    // prepare application with custom wasm keeper
+    let mut app = AppBuilder::default()
+        .with_wasm(wasm_keeper)
+        .build(|_, _, _| {});
+
+    // store contract's code
+    let code_id = app.store_code_with_creator(
+        Addr::unchecked("creator"),
+        test_contracts::counter::contract(),
+    );
+
+    // get code info
+    let code_info_response = app.wrap().query_wasm_code_info(code_id).unwrap();
+
+    // this should be custom checksum
+    assert_eq!(
+        code_info_response.checksum.to_hex(),
+        "c0ffee01c0ffee02c0ffee03c0ffee04c0ffee05c0ffee06c0ffee07c0ffee08"
+    );
+}

--- a/tests/test_wasm/test_with_checksum_gen.rs
+++ b/tests/test_wasm/test_with_checksum_gen.rs
@@ -28,7 +28,7 @@ fn default_checksum_generator_should_work() {
 struct MyChecksumGenerator;
 
 impl ChecksumGenerator for MyChecksumGenerator {
-    fn checksum(&self, _creator: Addr, _code_id: u64) -> HexBinary {
+    fn checksum(&self, _creator: &Addr, _code_id: u64) -> HexBinary {
         HexBinary::from_hex("c0ffee01c0ffee02c0ffee03c0ffee04c0ffee05c0ffee06c0ffee07c0ffee08")
             .unwrap()
     }
@@ -38,7 +38,7 @@ impl ChecksumGenerator for MyChecksumGenerator {
 fn custom_checksum_generator_should_work() {
     // prepare wasm keeper with custom checksum generator
     let wasm_keeper: WasmKeeper<Empty, Empty> =
-        WasmKeeper::default().new_with_checksum_generator(MyChecksumGenerator);
+        WasmKeeper::default().with_checksum_generator(MyChecksumGenerator);
 
     // prepare application with custom wasm keeper
     let mut app = AppBuilder::default()


### PR DESCRIPTION
Added a trait being an interface to provide custom checksum evaluator for contract's code.
Provided default implementation that is just SHA2 from text containing contract's code identifier.