### PR TITLE
Refactored modules

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,12 +8,12 @@ use crate::module::{FailingModule, Module};
 use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
 use crate::transactions::transactional;
 use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
-use crate::{AppBuilder, IbcFailingModule};
+use crate::{AppBuilder, GovFailingModule, IbcFailingModule};
 use cosmwasm_std::testing::{MockApi, MockStorage};
 use cosmwasm_std::{
     from_slice, to_binary, Addr, Api, Binary, BlockInfo, ContractResult, CosmosMsg, CustomQuery,
-    Empty, GovMsg, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record, Storage,
-    SystemError, SystemResult,
+    Empty, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record, Storage, SystemError,
+    SystemResult,
 };
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
@@ -35,6 +35,7 @@ pub type BasicApp<ExecC = Empty, QueryC = Empty> = App<
     StakeKeeper,
     DistributionKeeper,
     IbcFailingModule,
+    GovFailingModule,
 >;
 
 /// Router is a persisted state. You can query this.
@@ -50,7 +51,7 @@ pub struct App<
     Staking = StakeKeeper,
     Distr = DistributionKeeper,
     Ibc = IbcFailingModule,
-    Gov = FailingModule<GovMsg, Empty, Empty>,
+    Gov = GovFailingModule,
 > {
     pub(crate) router: Router<Bank, Custom, Wasm, Staking, Distr, Ibc, Gov>,
     pub(crate) api: Api,
@@ -83,7 +84,7 @@ impl BasicApp {
                 StakeKeeper,
                 DistributionKeeper,
                 IbcFailingModule,
-                FailingModule<GovMsg, Empty, Empty>,
+                GovFailingModule,
             >,
             &dyn Api,
             &mut dyn Storage,
@@ -107,7 +108,7 @@ where
             StakeKeeper,
             DistributionKeeper,
             IbcFailingModule,
-            FailingModule<GovMsg, Empty, Empty>,
+            GovFailingModule,
         >,
         &dyn Api,
         &mut dyn Storage,

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,12 +8,12 @@ use crate::module::{FailingModule, Module};
 use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
 use crate::transactions::transactional;
 use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
-use crate::AppBuilder;
+use crate::{AppBuilder, IbcFailingModule};
 use cosmwasm_std::testing::{MockApi, MockStorage};
 use cosmwasm_std::{
     from_slice, to_binary, Addr, Api, Binary, BlockInfo, ContractResult, CosmosMsg, CustomQuery,
-    Empty, GovMsg, IbcMsg, IbcQuery, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record,
-    Storage, SystemError, SystemResult,
+    Empty, GovMsg, Querier, QuerierResult, QuerierWrapper, QueryRequest, Record, Storage,
+    SystemError, SystemResult,
 };
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
@@ -34,7 +34,7 @@ pub type BasicApp<ExecC = Empty, QueryC = Empty> = App<
     WasmKeeper<ExecC, QueryC>,
     StakeKeeper,
     DistributionKeeper,
-    FailingModule<IbcMsg, IbcQuery, Empty>,
+    IbcFailingModule,
 >;
 
 /// Router is a persisted state. You can query this.
@@ -49,7 +49,7 @@ pub struct App<
     Wasm = WasmKeeper<Empty, Empty>,
     Staking = StakeKeeper,
     Distr = DistributionKeeper,
-    Ibc = FailingModule<IbcMsg, IbcQuery, Empty>,
+    Ibc = IbcFailingModule,
     Gov = FailingModule<GovMsg, Empty, Empty>,
 > {
     pub(crate) router: Router<Bank, Custom, Wasm, Staking, Distr, Ibc, Gov>,
@@ -82,7 +82,7 @@ impl BasicApp {
                 WasmKeeper<Empty, Empty>,
                 StakeKeeper,
                 DistributionKeeper,
-                FailingModule<IbcMsg, IbcQuery, Empty>,
+                IbcFailingModule,
                 FailingModule<GovMsg, Empty, Empty>,
             >,
             &dyn Api,
@@ -106,7 +106,7 @@ where
             WasmKeeper<ExecC, QueryC>,
             StakeKeeper,
             DistributionKeeper,
-            FailingModule<IbcMsg, IbcQuery, Empty>,
+            IbcFailingModule,
             FailingModule<GovMsg, Empty, Empty>,
         >,
         &dyn Api,

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -1,11 +1,11 @@
 //! Implementation of the builder for [App].
 
 use crate::{
-    App, Bank, BankKeeper, Distribution, DistributionKeeper, FailingModule, Gov, Ibc,
-    IbcFailingModule, Module, Router, StakeKeeper, Staking, Wasm, WasmKeeper,
+    App, Bank, BankKeeper, Distribution, DistributionKeeper, FailingModule, Gov, GovFailingModule,
+    Ibc, IbcFailingModule, Module, Router, StakeKeeper, Staking, Wasm, WasmKeeper,
 };
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
-use cosmwasm_std::{Api, BlockInfo, CustomQuery, Empty, GovMsg, Storage};
+use cosmwasm_std::{Api, BlockInfo, CustomQuery, Empty, Storage};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
@@ -34,7 +34,7 @@ pub type BasicAppBuilder<ExecC, QueryC> = AppBuilder<
     StakeKeeper,
     DistributionKeeper,
     IbcFailingModule,
-    FailingModule<GovMsg, Empty, Empty>,
+    GovFailingModule,
 >;
 
 /// Utility to build [App] in stages.
@@ -62,7 +62,7 @@ impl Default
         StakeKeeper,
         DistributionKeeper,
         IbcFailingModule,
-        FailingModule<GovMsg, Empty, Empty>,
+        GovFailingModule,
     >
 {
     fn default() -> Self {
@@ -80,7 +80,7 @@ impl
         StakeKeeper,
         DistributionKeeper,
         IbcFailingModule,
-        FailingModule<GovMsg, Empty, Empty>,
+        GovFailingModule,
     >
 {
     /// Creates builder with default components working with empty exec and query messages.
@@ -94,8 +94,8 @@ impl
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: IbcFailingModule::new(),
+            gov: GovFailingModule::new(),
         }
     }
 }
@@ -110,7 +110,7 @@ impl<ExecC, QueryC>
         StakeKeeper,
         DistributionKeeper,
         IbcFailingModule,
-        FailingModule<GovMsg, Empty, Empty>,
+        GovFailingModule,
     >
 where
     ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
@@ -128,8 +128,8 @@ where
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: IbcFailingModule::new(),
+            gov: GovFailingModule::new(),
         }
     }
 }

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -1,11 +1,11 @@
 //! Implementation of the builder for [App].
 
 use crate::{
-    App, Bank, BankKeeper, Distribution, DistributionKeeper, FailingModule, Gov, Ibc, Module,
-    Router, StakeKeeper, Staking, Wasm, WasmKeeper,
+    App, Bank, BankKeeper, Distribution, DistributionKeeper, FailingModule, Gov, Ibc,
+    IbcFailingModule, Module, Router, StakeKeeper, Staking, Wasm, WasmKeeper,
 };
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
-use cosmwasm_std::{Api, BlockInfo, CustomQuery, Empty, GovMsg, IbcMsg, IbcQuery, Storage};
+use cosmwasm_std::{Api, BlockInfo, CustomQuery, Empty, GovMsg, Storage};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
@@ -33,7 +33,7 @@ pub type BasicAppBuilder<ExecC, QueryC> = AppBuilder<
     WasmKeeper<ExecC, QueryC>,
     StakeKeeper,
     DistributionKeeper,
-    FailingModule<IbcMsg, IbcQuery, Empty>,
+    IbcFailingModule,
     FailingModule<GovMsg, Empty, Empty>,
 >;
 
@@ -61,7 +61,7 @@ impl Default
         WasmKeeper<Empty, Empty>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
+        IbcFailingModule,
         FailingModule<GovMsg, Empty, Empty>,
     >
 {
@@ -79,7 +79,7 @@ impl
         WasmKeeper<Empty, Empty>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
+        IbcFailingModule,
         FailingModule<GovMsg, Empty, Empty>,
     >
 {
@@ -109,7 +109,7 @@ impl<ExecC, QueryC>
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
+        IbcFailingModule,
         FailingModule<GovMsg, Empty, Empty>,
     >
 where

--- a/src/gov.rs
+++ b/src/gov.rs
@@ -1,6 +1,12 @@
-use crate::{FailingModule, Module};
+use crate::{AcceptingModule, FailingModule, Module};
 use cosmwasm_std::{Empty, GovMsg};
 
 pub trait Gov: Module<ExecT = GovMsg, QueryT = Empty, SudoT = Empty> {}
 
-impl Gov for FailingModule<GovMsg, Empty, Empty> {}
+pub type GovAcceptingModule = AcceptingModule<GovMsg, Empty, Empty>;
+
+impl Gov for GovAcceptingModule {}
+
+pub type GovFailingModule = FailingModule<GovMsg, Empty, Empty>;
+
+impl Gov for GovFailingModule {}

--- a/src/ibc.rs
+++ b/src/ibc.rs
@@ -1,62 +1,12 @@
-use crate::error::AnyResult;
-use crate::{AppResponse, FailingModule, Module};
-use cosmwasm_std::{Binary, Empty, IbcMsg, IbcQuery};
-use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
-use std::fmt::Debug;
+use crate::{AcceptingModule, FailingModule, Module};
+use cosmwasm_std::{Empty, IbcMsg, IbcQuery};
 
 pub trait Ibc: Module<ExecT = IbcMsg, QueryT = IbcQuery, SudoT = Empty> {}
 
-impl Ibc for FailingModule<IbcMsg, IbcQuery, Empty> {}
-
-pub struct IbcAcceptingModule;
-
-impl Module for IbcAcceptingModule {
-    type ExecT = IbcMsg;
-    type QueryT = IbcQuery;
-    type SudoT = Empty;
-
-    fn execute<ExecC, QueryC>(
-        &self,
-        _api: &dyn cosmwasm_std::Api,
-        _storage: &mut dyn cosmwasm_std::Storage,
-        _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-        _block: &cosmwasm_std::BlockInfo,
-        _sender: cosmwasm_std::Addr,
-        _msg: Self::ExecT,
-    ) -> AnyResult<AppResponse>
-    where
-        ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
-        QueryC: cosmwasm_std::CustomQuery + DeserializeOwned + 'static,
-    {
-        Ok(AppResponse::default())
-    }
-
-    fn sudo<ExecC, QueryC>(
-        &self,
-        _api: &dyn cosmwasm_std::Api,
-        _storage: &mut dyn cosmwasm_std::Storage,
-        _router: &dyn crate::CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-        _block: &cosmwasm_std::BlockInfo,
-        _msg: Self::SudoT,
-    ) -> AnyResult<AppResponse>
-    where
-        ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
-        QueryC: cosmwasm_std::CustomQuery + DeserializeOwned + 'static,
-    {
-        Ok(AppResponse::default())
-    }
-
-    fn query(
-        &self,
-        _api: &dyn cosmwasm_std::Api,
-        _storage: &dyn cosmwasm_std::Storage,
-        _querier: &dyn cosmwasm_std::Querier,
-        _block: &cosmwasm_std::BlockInfo,
-        _request: Self::QueryT,
-    ) -> AnyResult<Binary> {
-        Ok(Binary::default())
-    }
-}
+pub type IbcAcceptingModule = AcceptingModule<IbcMsg, IbcQuery, Empty>;
 
 impl Ibc for IbcAcceptingModule {}
+
+pub type IbcFailingModule = FailingModule<IbcMsg, IbcQuery, Empty>;
+
+impl Ibc for IbcFailingModule {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::checksums::ChecksumGenerator;
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::gov::Gov;
-pub use crate::ibc::{Ibc, IbcAcceptingModule};
+pub use crate::ibc::{Ibc, IbcAcceptingModule, IbcFailingModule};
 pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::checksums::ChecksumGenerator;
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
-pub use crate::gov::Gov;
+pub use crate::gov::{Gov, GovAcceptingModule, GovFailingModule};
 pub use crate::ibc::{Ibc, IbcAcceptingModule, IbcFailingModule};
 pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::gov::Gov;
 pub use crate::ibc::{Ibc, IbcAcceptingModule};
-pub use crate::module::{FailingModule, Module};
+pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };

--- a/src/module.rs
+++ b/src/module.rs
@@ -118,3 +118,65 @@ where
         bail!("Unexpected custom query {:?}", request)
     }
 }
+
+pub struct AcceptingModule<ExecT, QueryT, SudoT>(PhantomData<(ExecT, QueryT, SudoT)>);
+
+impl<ExecT, QueryT, SudoT> AcceptingModule<ExecT, QueryT, SudoT> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<ExecT, QueryT, SudoT> Default for AcceptingModule<ExecT, QueryT, SudoT> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<ExecT, QueryT, SudoT> Module for AcceptingModule<ExecT, QueryT, SudoT>
+where
+    ExecT: Debug,
+    QueryT: Debug,
+    SudoT: Debug,
+{
+    type ExecT = ExecT;
+    type QueryT = QueryT;
+    type SudoT = SudoT;
+
+    /// Runs any [ExecT](Self::ExecT) message, always returns a default response.
+    fn execute<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        _sender: Addr,
+        _msg: Self::ExecT,
+    ) -> AnyResult<AppResponse> {
+        Ok(AppResponse::default())
+    }
+
+    /// Runs any [SudoT](Self::SudoT) privileged action, always returns a default response.
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        _msg: Self::SudoT,
+    ) -> AnyResult<AppResponse> {
+        Ok(AppResponse::default())
+    }
+
+    /// Runs any [QueryT](Self::QueryT) message, always returns an empty binary.
+    fn query(
+        &self,
+        _api: &dyn Api,
+        _storage: &dyn Storage,
+        _querier: &dyn Querier,
+        _block: &BlockInfo,
+        _request: Self::QueryT,
+    ) -> AnyResult<Binary> {
+        Ok(Binary::default())
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -28,11 +28,22 @@ pub trait Module {
         ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
         QueryC: CustomQuery + DeserializeOwned + 'static;
 
+    /// Runs any [QueryT](Self::QueryT) message,
+    /// which can be called by any external actor or smart contract.
+    fn query(
+        &self,
+        api: &dyn Api,
+        storage: &dyn Storage,
+        querier: &dyn Querier,
+        block: &BlockInfo,
+        request: Self::QueryT,
+    ) -> AnyResult<Binary>;
+
     /// Runs privileged actions, like minting tokens, or governance proposals.
     /// This allows modules to have full access to these privileged actions,
     /// that cannot be triggered by smart contracts.
     ///
-    /// There is no sender, as this must be previously authorized before the call
+    /// There is no sender, as this must be previously authorized before calling.
     fn sudo<ExecC, QueryC>(
         &self,
         api: &dyn Api,
@@ -44,17 +55,6 @@ pub trait Module {
     where
         ExecC: Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
         QueryC: CustomQuery + DeserializeOwned + 'static;
-
-    /// Runs any [QueryT](Self::QueryT) message,
-    /// which can be called by any external actor or smart contract.
-    fn query(
-        &self,
-        api: &dyn Api,
-        storage: &dyn Storage,
-        querier: &dyn Querier,
-        block: &BlockInfo,
-        request: Self::QueryT,
-    ) -> AnyResult<Binary>;
 }
 
 pub struct FailingModule<ExecT, QueryT, SudoT>(PhantomData<(ExecT, QueryT, SudoT)>);
@@ -94,18 +94,6 @@ where
         bail!("Unexpected exec msg {:?} from {:?}", msg, sender)
     }
 
-    /// Runs any [SudoT](Self::SudoT) privileged action, always returns an error.
-    fn sudo<ExecC, QueryC>(
-        &self,
-        _api: &dyn Api,
-        _storage: &mut dyn Storage,
-        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-        _block: &BlockInfo,
-        msg: Self::SudoT,
-    ) -> AnyResult<AppResponse> {
-        bail!("Unexpected sudo msg {:?}", msg)
-    }
-
     /// Runs any [QueryT](Self::QueryT) message, always returns an error.
     fn query(
         &self,
@@ -116,6 +104,18 @@ where
         request: Self::QueryT,
     ) -> AnyResult<Binary> {
         bail!("Unexpected custom query {:?}", request)
+    }
+
+    /// Runs any [SudoT](Self::SudoT) privileged action, always returns an error.
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        msg: Self::SudoT,
+    ) -> AnyResult<AppResponse> {
+        bail!("Unexpected sudo msg {:?}", msg)
     }
 }
 
@@ -156,18 +156,6 @@ where
         Ok(AppResponse::default())
     }
 
-    /// Runs any [SudoT](Self::SudoT) privileged action, always returns a default response.
-    fn sudo<ExecC, QueryC>(
-        &self,
-        _api: &dyn Api,
-        _storage: &mut dyn Storage,
-        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-        _block: &BlockInfo,
-        _msg: Self::SudoT,
-    ) -> AnyResult<AppResponse> {
-        Ok(AppResponse::default())
-    }
-
     /// Runs any [QueryT](Self::QueryT) message, always returns an empty binary.
     fn query(
         &self,
@@ -178,5 +166,17 @@ where
         _request: Self::QueryT,
     ) -> AnyResult<Binary> {
         Ok(Binary::default())
+    }
+
+    /// Runs any [SudoT](Self::SudoT) privileged action, always returns a default response.
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        _msg: Self::SudoT,
+    ) -> AnyResult<AppResponse> {
+        Ok(AppResponse::default())
     }
 }

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -988,11 +988,14 @@ impl Module for DistributionKeeper {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{app::MockRouter, BankKeeper, FailingModule, IbcFailingModule, Router, WasmKeeper};
+    use crate::{
+        app::MockRouter, BankKeeper, FailingModule, GovFailingModule, IbcFailingModule, Router,
+        WasmKeeper,
+    };
     use cosmwasm_std::{
         from_slice,
         testing::{mock_env, MockApi, MockStorage},
-        BalanceResponse, BankQuery, GovMsg,
+        BalanceResponse, BankQuery,
     };
 
     /// Type alias for default build `Router` to make its reference in typical scenario
@@ -1003,7 +1006,7 @@ mod test {
         StakeKeeper,
         DistributionKeeper,
         IbcFailingModule,
-        FailingModule<GovMsg, Empty, Empty>,
+        GovFailingModule,
     >;
 
     fn mock_router() -> BasicRouter {
@@ -1013,8 +1016,8 @@ mod test {
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: IbcFailingModule::new(),
+            gov: GovFailingModule::new(),
         }
     }
 

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -987,14 +987,12 @@ impl Module for DistributionKeeper {
 
 #[cfg(test)]
 mod test {
-    use crate::{app::MockRouter, BankKeeper, FailingModule, Router, WasmKeeper};
-
     use super::*;
-
+    use crate::{app::MockRouter, BankKeeper, FailingModule, IbcFailingModule, Router, WasmKeeper};
     use cosmwasm_std::{
         from_slice,
         testing::{mock_env, MockApi, MockStorage},
-        BalanceResponse, BankQuery, GovMsg, IbcMsg, IbcQuery,
+        BalanceResponse, BankQuery, GovMsg,
     };
 
     /// Type alias for default build `Router` to make its reference in typical scenario
@@ -1004,7 +1002,7 @@ mod test {
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
+        IbcFailingModule,
         FailingModule<GovMsg, Empty, Empty>,
     >;
 

--- a/src/tests/test_ibc.rs
+++ b/src/tests/test_ibc.rs
@@ -24,7 +24,7 @@ fn default_ibc() {
 #[test]
 fn substituting_ibc() {
     let mut app = AppBuilder::new()
-        .with_ibc(IbcAcceptingModule)
+        .with_ibc(IbcAcceptingModule::new())
         .build(|_, _, _| ());
     let code = app.store_code(stargate::contract());
     let contract = app

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1119,11 +1119,11 @@ mod test {
     use crate::staking::{DistributionKeeper, StakeKeeper};
     use crate::test_helpers::{caller, error, payout};
     use crate::transactions::StorageTransaction;
-    use crate::IbcFailingModule;
+    use crate::{GovFailingModule, IbcFailingModule};
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coin, from_slice, to_vec, BankMsg, CanonicalAddr, Coin, CosmosMsg, Empty, GovMsg,
-        HexBinary, StdError,
+        coin, from_slice, to_vec, BankMsg, CanonicalAddr, Coin, CosmosMsg, Empty, HexBinary,
+        StdError,
     };
 
     /// Type alias for default build `Router` to make its reference in typical scenario
@@ -1134,7 +1134,7 @@ mod test {
         StakeKeeper,
         DistributionKeeper,
         IbcFailingModule,
-        FailingModule<GovMsg, Empty, Empty>,
+        GovFailingModule,
     >;
 
     fn wasm_keeper() -> WasmKeeper<Empty, Empty> {
@@ -1148,8 +1148,8 @@ mod test {
             custom: FailingModule::new(),
             staking: StakeKeeper::new(),
             distribution: DistributionKeeper::new(),
-            ibc: FailingModule::new(),
-            gov: FailingModule::new(),
+            ibc: IbcFailingModule::new(),
+            gov: GovFailingModule::new(),
         }
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1119,10 +1119,11 @@ mod test {
     use crate::staking::{DistributionKeeper, StakeKeeper};
     use crate::test_helpers::{caller, error, payout};
     use crate::transactions::StorageTransaction;
+    use crate::IbcFailingModule;
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
         coin, from_slice, to_vec, BankMsg, CanonicalAddr, Coin, CosmosMsg, Empty, GovMsg,
-        HexBinary, IbcMsg, IbcQuery, StdError,
+        HexBinary, StdError,
     };
 
     /// Type alias for default build `Router` to make its reference in typical scenario
@@ -1132,7 +1133,7 @@ mod test {
         WasmKeeper<ExecC, QueryC>,
         StakeKeeper,
         DistributionKeeper,
-        FailingModule<IbcMsg, IbcQuery, Empty>,
+        IbcFailingModule,
         FailingModule<GovMsg, Empty, Empty>,
     >;
 

--- a/tests/test_app_builder/mod.rs
+++ b/tests/test_app_builder/mod.rs
@@ -10,9 +10,13 @@ mod test_with_api;
 mod test_with_bank;
 mod test_with_block;
 mod test_with_distribution;
+mod test_with_gov;
+mod test_with_ibc;
 mod test_with_staking;
 mod test_with_storage;
 mod test_with_wasm;
+
+const NO_MESSAGE: &str = "";
 
 struct MyKeeper<ExecT, QueryT, SudoT>(
     PhantomData<(ExecT, QueryT, SudoT)>,

--- a/tests/test_app_builder/test_with_distribution.rs
+++ b/tests/test_app_builder/test_with_distribution.rs
@@ -1,4 +1,4 @@
-use crate::test_app_builder::MyKeeper;
+use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
 use cosmwasm_std::{Addr, DistributionMsg, Empty};
 use cw_multi_test::{AppBuilder, Distribution, Executor};
 
@@ -12,7 +12,7 @@ const EXECUTE_MSG: &str = "distribution execute called";
 fn building_app_with_custom_distribution_should_work() {
     // build custom distribution keeper
     // distribution keeper has no query or sudo messages
-    let distribution_keeper = MyDistributionKeeper::new(EXECUTE_MSG, "", "");
+    let distribution_keeper = MyDistributionKeeper::new(EXECUTE_MSG, NO_MESSAGE, NO_MESSAGE);
 
     // build the application with custom distribution keeper
     let app_builder = AppBuilder::default();

--- a/tests/test_app_builder/test_with_gov.rs
+++ b/tests/test_app_builder/test_with_gov.rs
@@ -1,0 +1,34 @@
+use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
+use cosmwasm_std::{Addr, Empty, GovMsg, VoteOption};
+use cw_multi_test::{AppBuilder, Executor, Gov};
+
+type MyGovKeeper = MyKeeper<GovMsg, Empty, Empty>;
+
+impl Gov for MyGovKeeper {}
+
+const EXECUTE_MSG: &str = "gov execute called";
+
+#[test]
+fn building_app_with_custom_gov_should_work() {
+    // build custom gov keeper (no query and sudo handling for gov)
+    let gov_keeper = MyGovKeeper::new(EXECUTE_MSG, NO_MESSAGE, NO_MESSAGE);
+
+    // build the application with custom gov keeper
+    let app_builder = AppBuilder::default();
+    let mut app = app_builder.with_gov(gov_keeper).build(|_, _, _| {});
+
+    // executing gov message should return an error defined in custom keeper
+    assert_eq!(
+        EXECUTE_MSG,
+        app.execute(
+            Addr::unchecked("sender"),
+            GovMsg::Vote {
+                proposal_id: 1,
+                vote: VoteOption::Yes,
+            }
+            .into(),
+        )
+        .unwrap_err()
+        .to_string()
+    );
+}

--- a/tests/test_app_builder/test_with_ibc.rs
+++ b/tests/test_app_builder/test_with_ibc.rs
@@ -1,0 +1,45 @@
+use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
+use cosmwasm_std::{Addr, Empty, IbcMsg, IbcQuery, QueryRequest};
+use cw_multi_test::{AppBuilder, Executor, Ibc};
+
+type MyIbcKeeper = MyKeeper<IbcMsg, IbcQuery, Empty>;
+
+impl Ibc for MyIbcKeeper {}
+
+const EXECUTE_MSG: &str = "ibc execute called";
+const QUERY_MSG: &str = "ibc query called";
+
+#[test]
+fn building_app_with_custom_ibc_should_work() {
+    // build custom ibc keeper (no sudo handling for ibc)
+    let ibc_keeper = MyIbcKeeper::new(EXECUTE_MSG, QUERY_MSG, NO_MESSAGE);
+
+    // build the application with custom ibc keeper
+    let app_builder = AppBuilder::default();
+    let mut app = app_builder.with_ibc(ibc_keeper).build(|_, _, _| {});
+
+    // executing ibc message should return an error defined in custom keeper
+    assert_eq!(
+        EXECUTE_MSG,
+        app.execute(
+            Addr::unchecked("sender"),
+            IbcMsg::CloseChannel {
+                channel_id: "my-channel".to_string()
+            }
+            .into(),
+        )
+        .unwrap_err()
+        .to_string()
+    );
+
+    // executing ibc query should return an error defined in custom keeper
+    assert_eq!(
+        format!("Generic error: Querier contract error: {}", QUERY_MSG),
+        app.wrap()
+            .query::<IbcQuery>(&QueryRequest::Ibc(IbcQuery::ListChannels {
+                port_id: Some("my-port".to_string())
+            }))
+            .unwrap_err()
+            .to_string()
+    );
+}

--- a/tests/test_module/mod.rs
+++ b/tests/test_module/mod.rs
@@ -1,1 +1,2 @@
+mod test_accepting_module;
 mod test_failing_module;

--- a/tests/test_module/test_accepting_module.rs
+++ b/tests/test_module/test_accepting_module.rs
@@ -8,9 +8,8 @@ fn eq(actual: AppResponse, expected: AppResponse) {
     assert_eq!(actual.data, expected.data);
 }
 
-#[test]
-fn accepting_module_default_works() {
-    let accepting_module: AcceptingModule<Empty, Empty, Empty> = AcceptingModule::default();
+/// Utility function for asserting default outputs returned from accepting module.
+fn assert_results(accepting_module: AcceptingModule<Empty, Empty, Empty>) {
     let app = App::default();
     let mut storage = MockStorage::default();
     eq(
@@ -53,45 +52,11 @@ fn accepting_module_default_works() {
 }
 
 #[test]
+fn accepting_module_default_works() {
+    assert_results(AcceptingModule::default());
+}
+
+#[test]
 fn accepting_module_new_works() {
-    let accepting_module: AcceptingModule<Empty, Empty, Empty> = AcceptingModule::new();
-    let app = App::default();
-    let mut storage = MockStorage::default();
-    eq(
-        AppResponse::default(),
-        accepting_module
-            .execute(
-                app.api(),
-                &mut storage,
-                app.router(),
-                &app.block_info(),
-                Addr::unchecked("sender"),
-                Empty {},
-            )
-            .unwrap(),
-    );
-    assert_eq!(
-        Binary::default(),
-        accepting_module
-            .query(
-                app.api(),
-                &storage,
-                &(*app.wrap()),
-                &app.block_info(),
-                Empty {}
-            )
-            .unwrap()
-    );
-    eq(
-        AppResponse::default(),
-        accepting_module
-            .sudo(
-                app.api(),
-                &mut storage,
-                app.router(),
-                &app.block_info(),
-                Empty {},
-            )
-            .unwrap(),
-    );
+    assert_results(AcceptingModule::new());
 }

--- a/tests/test_module/test_accepting_module.rs
+++ b/tests/test_module/test_accepting_module.rs
@@ -1,0 +1,97 @@
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_std::{Addr, Binary, Empty};
+use cw_multi_test::{AcceptingModule, App, AppResponse, Module};
+
+/// Utility function for comparing responses.
+fn eq(actual: AppResponse, expected: AppResponse) {
+    assert_eq!(actual.events, expected.events);
+    assert_eq!(actual.data, expected.data);
+}
+
+#[test]
+fn accepting_module_default_works() {
+    let accepting_module: AcceptingModule<Empty, Empty, Empty> = AcceptingModule::default();
+    let app = App::default();
+    let mut storage = MockStorage::default();
+    eq(
+        AppResponse::default(),
+        accepting_module
+            .execute(
+                app.api(),
+                &mut storage,
+                app.router(),
+                &app.block_info(),
+                Addr::unchecked("sender"),
+                Empty {},
+            )
+            .unwrap(),
+    );
+    assert_eq!(
+        Binary::default(),
+        accepting_module
+            .query(
+                app.api(),
+                &storage,
+                &(*app.wrap()),
+                &app.block_info(),
+                Empty {}
+            )
+            .unwrap()
+    );
+    eq(
+        AppResponse::default(),
+        accepting_module
+            .sudo(
+                app.api(),
+                &mut storage,
+                app.router(),
+                &app.block_info(),
+                Empty {},
+            )
+            .unwrap(),
+    );
+}
+
+#[test]
+fn accepting_module_new_works() {
+    let accepting_module: AcceptingModule<Empty, Empty, Empty> = AcceptingModule::new();
+    let app = App::default();
+    let mut storage = MockStorage::default();
+    eq(
+        AppResponse::default(),
+        accepting_module
+            .execute(
+                app.api(),
+                &mut storage,
+                app.router(),
+                &app.block_info(),
+                Addr::unchecked("sender"),
+                Empty {},
+            )
+            .unwrap(),
+    );
+    assert_eq!(
+        Binary::default(),
+        accepting_module
+            .query(
+                app.api(),
+                &storage,
+                &(*app.wrap()),
+                &app.block_info(),
+                Empty {}
+            )
+            .unwrap()
+    );
+    eq(
+        AppResponse::default(),
+        accepting_module
+            .sudo(
+                app.api(),
+                &mut storage,
+                app.router(),
+                &app.block_info(),
+                Empty {},
+            )
+            .unwrap(),
+    );
+}

--- a/tests/test_module/test_failing_module.rs
+++ b/tests/test_module/test_failing_module.rs
@@ -2,9 +2,8 @@ use cosmwasm_std::testing::MockStorage;
 use cosmwasm_std::{Addr, Empty};
 use cw_multi_test::{App, FailingModule, Module};
 
-#[test]
-fn failing_module_default_works() {
-    let failing_module: FailingModule<Empty, Empty, Empty> = FailingModule::default();
+/// Utility function for asserting outputs returned from failing module.
+fn assert_results(failing_module: FailingModule<Empty, Empty, Empty>) {
     let app = App::default();
     let mut storage = MockStorage::default();
     assert_eq!(
@@ -50,48 +49,11 @@ fn failing_module_default_works() {
 }
 
 #[test]
+fn failing_module_default_works() {
+    assert_results(FailingModule::default());
+}
+
+#[test]
 fn failing_module_new_works() {
-    let failing_module: FailingModule<Empty, Empty, Empty> = FailingModule::new();
-    let app = App::default();
-    let mut storage = MockStorage::default();
-    assert_eq!(
-        r#"Unexpected exec msg Empty from Addr("sender")"#,
-        failing_module
-            .execute(
-                app.api(),
-                &mut storage,
-                app.router(),
-                &app.block_info(),
-                Addr::unchecked("sender"),
-                Empty {}
-            )
-            .unwrap_err()
-            .to_string()
-    );
-    assert_eq!(
-        "Unexpected custom query Empty",
-        failing_module
-            .query(
-                app.api(),
-                &storage,
-                &(*app.wrap()),
-                &app.block_info(),
-                Empty {}
-            )
-            .unwrap_err()
-            .to_string()
-    );
-    assert_eq!(
-        "Unexpected sudo msg Empty",
-        failing_module
-            .sudo(
-                app.api(),
-                &mut storage,
-                app.router(),
-                &app.block_info(),
-                Empty {}
-            )
-            .unwrap_err()
-            .to_string()
-    );
+    assert_results(FailingModule::new());
 }


### PR DESCRIPTION
- Added `AcceptingModule` like existing `FailingModule`.
- Refactored accepting module in Ibc - now uses common `AcceptingModule`.
- Added type aliases for commonly used Ibc and Goc failing modules.
- Added tests for building `App` with custom Ibc and Gov modules.
- Refactored tests.