### PR TITLE
Added test for instantiate2

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::digest::Update;
 use sha2::{Digest, Sha256};
 
+mod test_app;
 mod test_app_builder;
 mod test_module;
 mod test_wasm;
@@ -206,6 +207,11 @@ mod test_addresses {
             creator: &CanonicalAddr,
             salt: &[u8],
         ) -> AnyResult<Addr> {
+            //TODO the line below before merging
+            println!(
+                "\nSalt in MockAddressGenerator.predictable_contract_address:\n\n{:?}\n",
+                salt
+            );
             let canonical_addr = instantiate2_address(checksum, creator, salt)?;
             Ok(Addr::unchecked(api.addr_humanize(&canonical_addr)?))
         }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -207,11 +207,6 @@ mod test_addresses {
             creator: &CanonicalAddr,
             salt: &[u8],
         ) -> AnyResult<Addr> {
-            //TODO remove the line below before merging
-            println!(
-                "\nSalt in MockAddressGenerator.predictable_contract_address:\n\n{:?}\n",
-                salt
-            );
             let canonical_addr = instantiate2_address(checksum, creator, salt)?;
             Ok(Addr::unchecked(api.addr_humanize(&canonical_addr)?))
         }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -207,7 +207,7 @@ mod test_addresses {
             creator: &CanonicalAddr,
             salt: &[u8],
         ) -> AnyResult<Addr> {
-            //TODO the line below before merging
+            //TODO remove the line below before merging
             println!(
                 "\nSalt in MockAddressGenerator.predictable_contract_address:\n\n{:?}\n",
                 salt

--- a/tests/test_app/mod.rs
+++ b/tests/test_app/mod.rs
@@ -1,0 +1,1 @@
+mod test_instantiate2;

--- a/tests/test_app/test_instantiate2.rs
+++ b/tests/test_app/test_instantiate2.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "cosmwasm_1_2")]
+
+use crate::test_addresses::MockAddressGenerator;
+use crate::test_api::MockApiBech32;
+use crate::test_contracts::counter;
+use cosmwasm_std::{to_json_binary, Empty, WasmMsg};
+use cw_multi_test::{AppBuilder, Executor, WasmKeeper};
+use cw_utils::parse_instantiate_response_data;
+
+#[test]
+fn instantiate2_works() {
+    // prepare the application with custom Api and custom address generator
+    let mut app = AppBuilder::default()
+        .with_api(MockApiBech32::new("juno"))
+        .with_wasm(WasmKeeper::default().with_address_generator(MockAddressGenerator))
+        .build(|_, _, _| {});
+
+    // prepare addresses for sender and creator
+    let sender = app.api().addr_make("sender");
+    let creator = app.api().addr_make("creator");
+
+    // store the contract's code
+    let code_id = app.store_code_with_creator(creator, counter::contract());
+
+    // prepare tha salt for predictable address
+    let salt = "bad kids".as_bytes();
+
+    // instantiate the contract with predictable address
+    let init_msg = to_json_binary(&Empty {}).unwrap();
+    let msg = WasmMsg::Instantiate2 {
+        admin: None,
+        code_id,
+        msg: init_msg,
+        funds: vec![],
+        label: "label".into(),
+        salt: salt.into(),
+    };
+    let res = app.execute(sender, msg.into()).unwrap();
+
+    // check the instantiate result
+    let parsed = parse_instantiate_response_data(res.data.unwrap().as_slice()).unwrap();
+    assert!(parsed.data.is_none());
+
+    // check the predictable contract's address
+    assert_eq!(
+        parsed.contract_address,
+        "juno1navvz5rjlvn43xjqxlpl7dunk6hglmhuh7c6a53eq6qamfam3dus7a220h"
+    );
+}

--- a/tests/test_app/test_instantiate2.rs
+++ b/tests/test_app/test_instantiate2.rs
@@ -3,7 +3,7 @@
 use crate::test_addresses::MockAddressGenerator;
 use crate::test_api::MockApiBech32;
 use crate::test_contracts::counter;
-use cosmwasm_std::{to_json_binary, Empty, WasmMsg};
+use cosmwasm_std::{instantiate2_address, to_json_binary, Api, Empty, WasmMsg};
 use cw_multi_test::{AppBuilder, Executor, WasmKeeper};
 use cw_utils::parse_instantiate_response_data;
 
@@ -22,7 +22,7 @@ fn instantiate2_works() {
     // store the contract's code
     let code_id = app.store_code_with_creator(creator, counter::contract());
 
-    // prepare tha salt for predictable address
+    // prepare the salt for predictable address
     let salt = "bad kids".as_bytes();
 
     // instantiate the contract with predictable address
@@ -35,15 +35,39 @@ fn instantiate2_works() {
         label: "label".into(),
         salt: salt.into(),
     };
-    let res = app.execute(sender, msg.into()).unwrap();
+    let res = app.execute(sender.clone(), msg.into()).unwrap();
 
     // check the instantiate result
     let parsed = parse_instantiate_response_data(res.data.unwrap().as_slice()).unwrap();
     assert!(parsed.data.is_none());
 
-    // check the predictable contract's address
+    // check the resulting predictable contract's address
     assert_eq!(
         parsed.contract_address,
         "juno1navvz5rjlvn43xjqxlpl7dunk6hglmhuh7c6a53eq6qamfam3dus7a220h"
     );
+
+    // ----------------------------------------------------------------------
+    // Below is an additional check, proving that the predictable address
+    // from contract instantiation is exactly the same as the address
+    // returned from the function cosmwasm_std::instantiate2_address
+    // ----------------------------------------------------------------------
+
+    // get the code info of the contract
+    let code_info_response = app.wrap().query_wasm_code_info(code_id).unwrap();
+
+    // retrieve the contract's code checksum
+    let checksum = code_info_response.checksum.as_slice();
+
+    // canonicalize the sender address (which is now in human Bech32 format)
+    let sender_addr = app.api().addr_canonicalize(sender.as_str()).unwrap();
+
+    // get the contract address using cosmwasm_std::instantiate2_address function
+    let contract_addr = instantiate2_address(checksum, &sender_addr, salt).unwrap();
+
+    // humanize the address of the contract
+    let contract_human_addr = app.api().addr_humanize(&contract_addr).unwrap();
+
+    // check if the predictable contract's address matches the result from instantiate2_address function
+    assert_eq!(parsed.contract_address, contract_human_addr.to_string());
 }


### PR DESCRIPTION
Added test for instantiate2 function with custom `Api` and custom address generator that (both together) handle Bech32 addresses. It is an example how to handle Bech32 addresses like in use case described in the issue #95.