### PR TITLE
Fixed typos

### DIFF
--- a/src/prefixed_storage/length_prefixed.rs
+++ b/src/prefixed_storage/length_prefixed.rs
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn to_length_prefixed_calculates_capacity_correctly() {
         // Those tests cannot guarantee the required capacity was calculated correctly before
-        // the vector allocation but increase the likelyhood of a proper implementation.
+        // the vector allocation but increase the likelihood of a proper implementation.
 
         let key = to_length_prefixed(b"");
         assert_eq!(key.capacity(), key.len());
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn to_length_prefixed_nested_calculates_capacity_correctly() {
         // Those tests cannot guarantee the required capacity was calculated correctly before
-        // the vector allocation but increase the likelyhood of a proper implementation.
+        // the vector allocation but increase the likelihood of a proper implementation.
 
         let key = to_length_prefixed_nested(&[]);
         assert_eq!(key.capacity(), key.len());

--- a/src/tests/test_app.rs
+++ b/src/tests/test_app.rs
@@ -622,7 +622,7 @@ fn reflect_sub_message_reply_works() {
         )
         .unwrap();
 
-    // no reply writen beforehand
+    // no reply written beforehand
     let query = reflect::QueryMsg::Reply { id: 123 };
     let res: StdResult<Reply> = app.wrap().query_wasm_smart(&reflect_addr, &query);
     res.unwrap_err();


### PR DESCRIPTION
Used [`typos`](https://github.com/crate-ci/typos) to check the **MultiTest** repository with the following configuration file:

**typos.toml**
```toml
[default.extend-words]
fo = "fo"
```

No more warnings reported by `typos`.