### PR TITLE
Feature-gates in pattern matching of CosmWasm 2.0 Enum Variants

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -663,6 +663,7 @@ where
             CosmosMsg::Stargate { type_url, value } => self
                 .stargate
                 .execute_stargate(api, storage, self, block, sender, type_url, value),
+            #[cfg(feature = "cosmwasm_2_0")]
             CosmosMsg::Any(msg) => self
                 .stargate
                 .execute_any(api, storage, self, block, sender, msg),
@@ -691,6 +692,7 @@ where
             QueryRequest::Stargate { path, data } => self
                 .stargate
                 .query_stargate(api, storage, &querier, block, path, data),
+            #[cfg(feature = "cosmwasm_2_0")]
             QueryRequest::Grpc(req) => self.stargate.query_grpc(api, storage, &querier, block, req),
             _ => unimplemented!(),
         }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -434,6 +434,7 @@ where
             CosmosMsg::Distribution(distribution) => CosmosMsg::Distribution(distribution),
             CosmosMsg::Custom(_) => unreachable!(),
             CosmosMsg::Ibc(ibc) => CosmosMsg::Ibc(ibc),
+            #[cfg(feature = "cosmwasm_2_0")]
             CosmosMsg::Any(any) => CosmosMsg::Any(any),
             _ => panic!("unknown message variant {:?}", msg),
         },


### PR DESCRIPTION
With the `cosmwasm_2_0` default feature disabled, compilation of `cw-multi-test` fails with an error along the lines of the below:
```
error[E0599]: no variant or associated item named `Any` found for enum `CosmosMsg` in the current scope
   --> /cw-multi-test-2.0.1/src/app.rs:666:24
    |
666 |             CosmosMsg::Any(msg) => self
    |                        ^^^ variant or associated item not found in `CosmosMsg<_>`

error[E0599]: no variant or associated item named `Grpc` found for enum `QueryRequest` in the current scope
   --> /cw-multi-test-2.0.1/src/app.rs:694:27
    |
694 |             QueryRequest::Grpc(req) => self.stargate.query_grpc(api, storage, &querier, block, req),
    |                           ^^^^ variant or associated item not found in `QueryRequest<_>`
```

This PR feature gates these enums to allow compilation to succeed when the `cosmwasm_2_0` feature is disabled.