### PR TITLE
Refactoring staking module, part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,9 +526,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -17,6 +17,9 @@ use std::collections::{BTreeSet, VecDeque};
 /// Default denominator of the staking token.
 const BONDED_DENOM: &str = "TOKEN";
 
+/// One year expressed in seconds.
+const YEAR: u64 = 60 * 60 * 24 * 365;
+
 /// A structure containing some general staking parameters.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct StakingInfo {
@@ -25,7 +28,6 @@ pub struct StakingInfo {
     /// Time between unbonding and receiving tokens back (in seconds).
     pub unbonding_time: u64,
     /// Annual percentage rate (interest rate and any additional fees associated with bonding).
-    /// 1 year = 60 * 60 * 24 * 365 seconds.
     pub apr: Decimal,
 }
 
@@ -276,7 +278,7 @@ impl StakeKeeper {
         let reward = Decimal::from_ratio(stake, 1u128)
             * interest_rate
             * Decimal::from_ratio(time_diff, 1u128)
-            / Decimal::from_ratio(60u128 * 60 * 24 * 365, 1u128);
+            / Decimal::from_ratio(YEAR, 1u128);
         let commission = reward * validator_commission;
 
         reward - commission
@@ -1038,9 +1040,6 @@ mod test {
         BalanceResponse, BankQuery,
     };
 
-    /// One year expressed in seconds.
-    const YEAR: u64 = 60 * 60 * 24 * 365;
-
     /// Type alias for default build of [Router], to make its reference in typical test scenario.
     type BasicRouter<ExecC = Empty, QueryC = Empty> = Router<
         BankKeeper,
@@ -1747,7 +1746,7 @@ mod test {
             .unwrap();
 
             // A year passes.
-            env.block.time = env.block.time.plus_seconds(60 * 60 * 24 * 365);
+            env.block.time = env.block.time.plus_seconds(YEAR);
 
             // Withdraw rewards to reward receiver.
             execute_distr(
@@ -1770,7 +1769,7 @@ mod test {
             .unwrap();
 
             // Another year passes.
-            env.block.time = env.block.time.plus_seconds(60 * 60 * 24 * 365);
+            env.block.time = env.block.time.plus_seconds(YEAR);
 
             // Withdraw rewards to delegator.
             execute_distr(

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1041,9 +1041,6 @@ mod test {
     /// One year expressed in seconds.
     const YEAR: u64 = 60 * 60 * 24 * 365;
 
-    /// Half a year expressed in seconds.
-    const HALF_YEAR: u64 = YEAR / 2;
-
     /// Type alias for default build of [Router], to make its reference in typical test scenario.
     type BasicRouter<ExecC = Empty, QueryC = Empty> = Router<
         BankKeeper,
@@ -1259,7 +1256,7 @@ mod test {
             .unwrap();
 
         // wait 1/2 year
-        block.time = block.time.plus_seconds(HALF_YEAR);
+        block.time = block.time.plus_seconds(YEAR / 2);
 
         // should now have 200 * 10% / 2 - 10% commission = 9 tokens reward
         let rewards = stake
@@ -1290,7 +1287,7 @@ mod test {
         assert_eq!(rewards.amount.u128(), 0);
 
         // wait another 1/2 year
-        block.time = block.time.plus_seconds(HALF_YEAR);
+        block.time = block.time.plus_seconds(YEAR / 2);
         // should now have 9 tokens again
         let rewards = stake
             .get_rewards(&store, &block, &delegator_addr, &validator_addr)

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1067,8 +1067,8 @@ mod test {
     }
 
     fn setup_test_env(
-        apr: Decimal,
-        validator_commission: Decimal,
+        apr: u64,
+        validator_commission: u64,
     ) -> (MockApi, MockStorage, BasicRouter, BlockInfo, Addr) {
         let api = MockApi::default();
         let router = mock_router();
@@ -1084,7 +1084,7 @@ mod test {
                 StakingInfo {
                     bonded_denom: BONDED_DENOM.to_string(),
                     unbonding_time: 60,
-                    apr,
+                    apr: Decimal::percent(apr),
                 },
             )
             .unwrap();
@@ -1092,7 +1092,7 @@ mod test {
         // add validator
         let valoper1 = Validator::new(
             validator_addr.to_string(),
-            validator_commission,
+            Decimal::percent(validator_commission),
             Decimal::percent(100),
             Decimal::percent(1),
         );
@@ -1236,8 +1236,7 @@ mod test {
 
     #[test]
     fn rewards_work_for_single_delegator() {
-        let (api, mut store, router, mut block, validator_addr) =
-            setup_test_env(Decimal::percent(10), Decimal::percent(10));
+        let (api, mut store, router, mut block, validator_addr) = setup_test_env(10, 10);
         let stake = &router.staking;
         let distr = &router.distribution;
         let delegator_addr = api.addr_make("delegator");
@@ -1298,8 +1297,7 @@ mod test {
 
     #[test]
     fn rewards_work_for_multiple_delegators() {
-        let (api, mut store, router, mut block, validator) =
-            setup_test_env(Decimal::percent(10), Decimal::percent(10));
+        let (api, mut store, router, mut block, validator) = setup_test_env(10, 10);
         let stake = &router.staking;
         let distr = &router.distribution;
         let bank = &router.bank;
@@ -1546,8 +1544,7 @@ mod test {
         #[test]
         fn execute() {
             // test all execute msgs
-            let (mut test_env, validator1) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator1) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator1 = test_env.api.addr_make("delegator1");
             let reward_receiver = test_env.api.addr_make("rewardreceiver");
@@ -1688,8 +1685,7 @@ mod test {
 
         #[test]
         fn can_set_withdraw_address() {
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator = test_env.api.addr_make("delegator");
             let reward_receiver = test_env.api.addr_make("rewardreceiver");
@@ -1768,8 +1764,7 @@ mod test {
 
         #[test]
         fn cannot_steal() {
-            let (mut test_env, validator1) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator1) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator1 = test_env.api.addr_make("delegator1");
 
@@ -1857,8 +1852,7 @@ mod test {
 
         #[test]
         fn denom_validation() {
-            let (mut test_env, validator_addr) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator_addr) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator_addr = test_env.api.addr_make("delegator");
 
@@ -1892,8 +1886,7 @@ mod test {
 
         #[test]
         fn cannot_slash_nonexistent() {
-            let (mut test_env, _) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, _) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator = test_env.api.addr_make("delegator");
             let non_existing_validator = test_env.api.addr_make("nonexistingvaloper");
@@ -1925,8 +1918,7 @@ mod test {
 
         #[test]
         fn non_existent_validator() {
-            let (mut test_env, _) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, _) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator = test_env.api.addr_make("delegator1");
             let validator = test_env.api.addr_make("testvaloper2");
@@ -1969,8 +1961,7 @@ mod test {
 
         #[test]
         fn zero_staking_forbidden() {
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 10));
 
             let delegator_addr = test_env.api.addr_make("delegator");
 
@@ -2002,8 +1993,7 @@ mod test {
         #[test]
         fn query_staking() {
             // run all staking queries
-            let (mut test_env, validator1) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator1) = TestEnv::wrap(setup_test_env(10, 10));
             let delegator1 = test_env.api.addr_make("delegator1");
             let delegator2 = test_env.api.addr_make("delegator2");
             let validator2 = test_env.api.addr_make("testvaloper2");
@@ -2170,8 +2160,7 @@ mod test {
         #[test]
         fn delegation_queries_unbonding() {
             // run all staking queries
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 10));
             let delegator1 = test_env.api.addr_make("delegator1");
             let delegator2 = test_env.api.addr_make("delegator2");
 
@@ -2307,8 +2296,7 @@ mod test {
 
         #[test]
         fn partial_unbonding_reduces_stake() {
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 10));
             let delegator = test_env.api.addr_make("delegator1");
 
             // init balance
@@ -2435,8 +2423,7 @@ mod test {
         #[test]
         fn delegations_slashed() {
             // run all staking queries
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::percent(10)));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 10));
             let delegator = test_env.api.addr_make("delegator");
 
             // init balance
@@ -2528,8 +2515,7 @@ mod test {
 
         #[test]
         fn rewards_initial_wait() {
-            let (mut test_env, validator) =
-                TestEnv::wrap(setup_test_env(Decimal::percent(10), Decimal::zero()));
+            let (mut test_env, validator) = TestEnv::wrap(setup_test_env(10, 0));
             let delegator = test_env.api.addr_make("delegator");
 
             // init balance


### PR DESCRIPTION
- Introduced constant `BONDED_DENOM` for staking token denominator.
- Introduced constant `YEAR` (only in tests), containing length of 1 year expressed in seconds.
- Simplified arguments passed to `setup_test_env` helper function.
- Unified and renamed variable `test_env` to `env` in all tests (shorter name).
- Unified local variable names in all test cases.

**NO FUNCTIONAL CHANGES**