### PR TITLE
Refactoring staking module, part 2

### DIFF
--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1213,6 +1213,17 @@ mod test {
         )?)?)
     }
 
+    fn init_balance(env: &mut TestEnv, address: &Addr, amount: u128) {
+        init_balance_denom(env, address, amount, BONDED_DENOM);
+    }
+
+    fn init_balance_denom(env: &mut TestEnv, address: &Addr, amount: u128, denom: &str) {
+        env.router
+            .bank
+            .init_balance(&mut env.store, address, coins(amount, denom))
+            .unwrap();
+    }
+
     fn assert_balances(env: &TestEnv, balances: impl IntoIterator<Item = (Addr, u128)>) {
         for (addr, amount) in balances {
             let balance: BalanceResponse = query_bank(
@@ -1594,15 +1605,8 @@ mod test {
         let delegator_addr_1 = env.delegator_addr_2();
         let reward_receiver_addr = env.user_addr_1();
 
-        // initialize delegator account
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(1000, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 1000);
 
         // delegate 100 tokens to validator 1
         execute_stake(
@@ -1711,12 +1715,10 @@ mod test {
         let delegator_addr_1 = env.delegator_addr_1();
         let reward_receiver_addr = env.user_addr_1();
 
-        env.router
-            .bank
-            .init_balance(&mut env.store, &delegator_addr_1, coins(100, BONDED_DENOM))
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
 
-        // Stake 100 tokens to the validator.
+        // stake (delegate) 100 tokens to the validator
         execute_stake(
             &mut env,
             delegator_addr_1.clone(),
@@ -1727,7 +1729,7 @@ mod test {
         )
         .unwrap();
 
-        // Change rewards receiver.
+        // change the receiver of rewards
         execute_distr(
             &mut env,
             delegator_addr_1.clone(),
@@ -1737,7 +1739,7 @@ mod test {
         )
         .unwrap();
 
-        // A year passes.
+        // let one year pass
         env.block.time = env.block.time.plus_seconds(YEAR);
 
         // Withdraw rewards to reward receiver.
@@ -1793,15 +1795,8 @@ mod test {
         let validator_addr_2 = env.validator_addr_2();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // initialize delegator account
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(100, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
 
         // delegate 100 tokens to validator 1
         execute_stake(
@@ -1863,11 +1858,8 @@ mod test {
         let validator_addr_1 = env.validator_addr_1();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // fund delegator account
-        env.router
-            .bank
-            .init_balance(&mut env.store, &delegator_addr_1, vec![coin(100, "FAKE")])
-            .unwrap();
+        // init balances
+        init_balance_denom(&mut env, &delegator_addr_1, 100, "FAKE");
 
         // try to delegate 100 to validator
         let e = execute_stake(
@@ -1893,11 +1885,8 @@ mod test {
         let validator_addr_3 = env.validator_addr_3();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // fund delegator account
-        env.router
-            .bank
-            .init_balance(&mut env.store, &delegator_addr_1, vec![coin(100, "FAKE")])
-            .unwrap();
+        // init balances
+        init_balance_denom(&mut env, &delegator_addr_1, 100, "FAKE");
 
         // try to delegate 100 to non existing validator
         let e = env
@@ -1925,15 +1914,8 @@ mod test {
         let validator_addr_3 = env.validator_addr_3();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // init balances
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(100, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
 
         // try to delegate
         let err = execute_stake(
@@ -2002,23 +1984,9 @@ mod test {
         let delegator_addr_2 = env.delegator_addr_2();
         let user_addr_1 = env.user_addr_1();
 
-        // init balances
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(260, BONDED_DENOM)],
-            )
-            .unwrap();
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_2,
-                vec![coin(150, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 260);
+        init_balance(&mut env, &delegator_addr_2, 150);
 
         // query validators
         let valoper1: ValidatorResponse = query_stake(
@@ -2157,23 +2125,9 @@ mod test {
         let delegator_addr_1 = env.delegator_addr_1();
         let delegator_addr_2 = env.delegator_addr_2();
 
-        // init balances
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(100, BONDED_DENOM)],
-            )
-            .unwrap();
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_2,
-                vec![coin(150, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
+        init_balance(&mut env, &delegator_addr_2, 150);
 
         // delegate some tokens with delegator1 and delegator2
         execute_stake(
@@ -2292,15 +2246,8 @@ mod test {
         let validator_addr_1 = env.validator_addr_1();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // init balance
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(100, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
 
         // delegate all tokens
         execute_stake(
@@ -2407,17 +2354,10 @@ mod test {
         let validator_addr_1 = env.validator_addr_1();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // init balance
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(333, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 333);
 
-        // delegate some tokens
+        // stake (delegate) some tokens
         execute_stake(
             &mut env,
             delegator_addr_1.clone(),
@@ -2427,7 +2367,8 @@ mod test {
             },
         )
         .unwrap();
-        // unstake some
+
+        // unstake (undelegate) some tokens
         execute_stake(
             &mut env,
             delegator_addr_1.clone(),
@@ -2480,30 +2421,23 @@ mod test {
             QuerierWrapper::<Empty>::new(&env.router.querier(&env.api, &env.store, &env.block))
                 .query_balance(delegator_addr_1, BONDED_DENOM)
                 .unwrap();
-        assert_eq!(balance.amount.u128(), 55);
+        assert_eq!(55, balance.amount.u128());
     }
 
     #[test]
     fn rewards_initial_wait() {
-        let mut env = TestEnv::new((0, 100, 1), (10, 100, 1));
+        let mut env = TestEnv::new((0, 100, 1), (0, 100, 1));
 
         let validator_addr_1 = env.validator_addr_1();
         let delegator_addr_1 = env.delegator_addr_1();
 
-        // initialize balances for delegator
-        env.router
-            .bank
-            .init_balance(
-                &mut env.store,
-                &delegator_addr_1,
-                vec![coin(100, BONDED_DENOM)],
-            )
-            .unwrap();
+        // initialize balances
+        init_balance(&mut env, &delegator_addr_1, 100);
 
         // wait one year before staking
         env.block.time = env.block.time.plus_seconds(YEAR);
 
-        // stake (delegate) some tokens to validator
+        // stake (delegate) 100 tokens to validator
         execute_stake(
             &mut env,
             delegator_addr_1.clone(),

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1245,11 +1245,11 @@ mod test {
     fn add_get_validators() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 100, 1), (0, 20, 1)));
 
-        let validator_addr = env.validator_addr_3();
+        let validator_addr_3 = env.validator_addr_3();
 
         // add a new validator (validator no. 3 does not exist yet)
         let validator = Validator::new(
-            validator_addr.to_string(),
+            validator_addr_3.to_string(),
             Decimal::percent(10),
             Decimal::percent(20),
             Decimal::percent(1),
@@ -1264,14 +1264,14 @@ mod test {
         let val = env
             .router
             .staking
-            .get_validator(&staking_storage, &validator_addr)
+            .get_validator(&staking_storage, &validator_addr_3)
             .unwrap()
             .unwrap();
         assert_eq!(val, validator);
 
         // try to add a validator with same address (validator no. 3)
         let validator_fake = Validator::new(
-            validator_addr.to_string(),
+            validator_addr_3.to_string(),
             Decimal::percent(1),
             Decimal::percent(10),
             Decimal::percent(100),
@@ -1286,7 +1286,7 @@ mod test {
         let val = env
             .router
             .staking
-            .get_validator(&staking_storage, &validator_addr)
+            .get_validator(&staking_storage, &validator_addr_3)
             .unwrap()
             .unwrap();
         assert_eq!(val, validator);
@@ -1296,8 +1296,8 @@ mod test {
     fn validator_slashing() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 20, 1), (10, 20, 1)));
 
-        let validator_addr = env.validator_addr_1();
-        let delegator_addr = env.delegator_addr_1();
+        let validator_addr_1 = env.validator_addr_1();
+        let delegator_addr_1 = env.delegator_addr_1();
 
         // stake (delegate) 100 tokens from delegator to validator
         let mut staking_storage = prefixed(&mut env.store, NAMESPACE_STAKING);
@@ -1307,8 +1307,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator_addr,
-                &validator_addr,
+                &delegator_addr_1,
+                &validator_addr_1,
                 coin(100, BONDED_DENOM),
             )
             .unwrap();
@@ -1322,7 +1322,7 @@ mod test {
                 &env.router,
                 &env.block,
                 StakingSudo::Slash {
-                    validator: validator_addr.to_string(),
+                    validator: validator_addr_1.to_string(),
                     percentage: Decimal::percent(50),
                 },
             )
@@ -1333,7 +1333,7 @@ mod test {
         let stake_left = env
             .router
             .staking
-            .get_stake(&staking_storage, &delegator_addr, &validator_addr)
+            .get_stake(&staking_storage, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(50, stake_left.amount.u128());
@@ -1347,7 +1347,7 @@ mod test {
                 &env.router,
                 &env.block,
                 StakingSudo::Slash {
-                    validator: validator_addr.to_string(),
+                    validator: validator_addr_1.to_string(),
                     percentage: Decimal::percent(100),
                 },
             )
@@ -1358,7 +1358,7 @@ mod test {
         let stake_left = env
             .router
             .staking
-            .get_stake(&staking_storage, &delegator_addr, &validator_addr)
+            .get_stake(&staking_storage, &delegator_addr_1, &validator_addr_1)
             .unwrap();
         assert_eq!(None, stake_left);
     }
@@ -1367,8 +1367,8 @@ mod test {
     fn rewards_work_for_single_delegator() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 20, 1), (10, 20, 1)));
 
-        let validator_addr = env.validator_addr_1();
-        let delegator_addr = env.delegator_addr_1();
+        let validator_addr_1 = env.validator_addr_1();
+        let delegator_addr_1 = env.delegator_addr_1();
 
         let mut staking_storage = prefixed(&mut env.store, NAMESPACE_STAKING);
         // stake 200 tokens
@@ -1378,8 +1378,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator_addr,
-                &validator_addr,
+                &delegator_addr_1,
+                &validator_addr_1,
                 coin(200, BONDED_DENOM),
             )
             .unwrap();
@@ -1391,7 +1391,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator_addr, &validator_addr)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(9, rewards.amount.u128());
@@ -1404,9 +1404,9 @@ mod test {
                 &mut env.store,
                 &env.router,
                 &env.block,
-                delegator_addr.clone(),
+                delegator_addr_1.clone(),
                 DistributionMsg::WithdrawDelegatorReward {
-                    validator: validator_addr.to_string(),
+                    validator: validator_addr_1.to_string(),
                 },
             )
             .unwrap();
@@ -1415,7 +1415,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator_addr, &validator_addr)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(0, rewards.amount.u128());
@@ -1426,7 +1426,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator_addr, &validator_addr)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(9, rewards.amount.u128());
@@ -1436,9 +1436,9 @@ mod test {
     fn rewards_work_for_multiple_delegators() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 100, 1), (10, 100, 1)));
 
-        let validator = env.validator_addr_1();
-        let delegator1 = env.delegator_addr_1();
-        let delegator2 = env.delegator_addr_2();
+        let validator_addr_1 = env.validator_addr_1();
+        let delegator_addr_1 = env.delegator_addr_1();
+        let delegator_addr_2 = env.delegator_addr_2();
 
         let mut staking_storage = prefixed(&mut env.store, NAMESPACE_STAKING);
 
@@ -1449,8 +1449,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator1,
-                &validator,
+                &delegator_addr_1,
+                &validator_addr_1,
                 coin(100, BONDED_DENOM),
             )
             .unwrap();
@@ -1460,8 +1460,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator2,
-                &validator,
+                &delegator_addr_2,
+                &validator_addr_1,
                 coin(200, BONDED_DENOM),
             )
             .unwrap();
@@ -1473,7 +1473,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator1, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(rewards.amount.u128(), 9);
@@ -1482,7 +1482,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator2, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_2, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(rewards.amount.u128(), 18);
@@ -1495,8 +1495,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator1,
-                &validator,
+                &delegator_addr_1,
+                &validator_addr_1,
                 coin(100, BONDED_DENOM),
             )
             .unwrap();
@@ -1508,7 +1508,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator1, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(rewards.amount.u128(), 27);
@@ -1517,7 +1517,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator2, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_2, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(rewards.amount.u128(), 36);
@@ -1530,8 +1530,8 @@ mod test {
                 &env.api,
                 &mut staking_storage,
                 &env.block,
-                &delegator2,
-                &validator,
+                &delegator_addr_2,
+                &validator_addr_1,
                 coin(100, BONDED_DENOM),
             )
             .unwrap();
@@ -1544,9 +1544,9 @@ mod test {
                 &mut env.store,
                 &env.router,
                 &env.block,
-                delegator1.clone(),
+                delegator_addr_1.clone(),
                 DistributionMsg::WithdrawDelegatorReward {
-                    validator: validator.to_string(),
+                    validator: validator_addr_1.to_string(),
                 },
             )
             .unwrap();
@@ -1560,7 +1560,7 @@ mod test {
                     &env.router.querier(&env.api, &env.store, &env.block),
                     &env.block,
                     BankQuery::Balance {
-                        address: delegator1.to_string(),
+                        address: delegator_addr_1.to_string(),
                         denom: BONDED_DENOM.to_string(),
                     },
                 )
@@ -1572,7 +1572,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator1, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(0, rewards.amount.u128());
@@ -1584,7 +1584,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator1, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_1, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(18, rewards.amount.u128());
@@ -1593,7 +1593,7 @@ mod test {
         let rewards = env
             .router
             .staking
-            .get_rewards(&env.store, &env.block, &delegator2, &validator)
+            .get_rewards(&env.store, &env.block, &delegator_addr_2, &validator_addr_1)
             .unwrap()
             .unwrap();
         assert_eq!(45, rewards.amount.u128());
@@ -1904,7 +1904,7 @@ mod test {
     fn cannot_slash_nonexistent() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 100, 1), (10, 100, 1)));
 
-        let non_existing_validator_addr = env.validator_addr_3();
+        let validator_addr_3 = env.validator_addr_3();
         let delegator_addr_1 = env.delegator_addr_1();
 
         // fund delegator account
@@ -1923,7 +1923,7 @@ mod test {
                 &env.router,
                 &env.block,
                 StakingSudo::Slash {
-                    validator: non_existing_validator_addr.to_string(),
+                    validator: validator_addr_3.to_string(),
                     percentage: Decimal::percent(50),
                 },
             )
@@ -1936,7 +1936,7 @@ mod test {
     fn non_existent_validator() {
         let mut env = TestEnv::wrap(TestEnv::setup((10, 100, 1), (10, 100, 1)));
 
-        let non_existing_validator_addr = env.validator_addr_3();
+        let validator_addr_3 = env.validator_addr_3();
         let delegator_addr_1 = env.delegator_addr_1();
 
         // init balances
@@ -1954,7 +1954,7 @@ mod test {
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Delegate {
-                validator: non_existing_validator_addr.to_string(),
+                validator: validator_addr_3.to_string(),
                 amount: coin(100, BONDED_DENOM),
             },
         )
@@ -1966,7 +1966,7 @@ mod test {
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Undelegate {
-                validator: non_existing_validator_addr.to_string(),
+                validator: validator_addr_3.to_string(),
                 amount: coin(100, BONDED_DENOM),
             },
         )
@@ -2014,7 +2014,7 @@ mod test {
         let validator_addr_2 = env.validator_addr_2();
         let delegator_addr_1 = env.delegator_addr_1();
         let delegator_addr_2 = env.delegator_addr_2();
-        let not_validator_addr = env.user_addr_1();
+        let user_addr_1 = env.user_addr_1();
 
         // init balances
         env.router
@@ -2061,7 +2061,7 @@ mod test {
         let response = query_stake::<ValidatorResponse>(
             &env,
             StakingQuery::Validator {
-                address: not_validator_addr.to_string(),
+                address: user_addr_1.to_string(),
             },
         )
         .unwrap();

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1810,7 +1810,7 @@ mod test {
         .unwrap();
 
         // undelegate more tokens than we have
-        let e = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Undelegate {
@@ -1819,11 +1819,10 @@ mod test {
             },
         )
         .unwrap_err();
-
-        assert_eq!(e.to_string(), "invalid shares amount");
+        assert_eq!(error_result.to_string(), "invalid shares amount");
 
         // redelegate more tokens than we have from validator 1 to validator 2
-        let e = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Redelegate {
@@ -1833,10 +1832,10 @@ mod test {
             },
         )
         .unwrap_err();
-        assert_eq!(e.to_string(), "invalid shares amount");
+        assert_eq!(error_result.to_string(), "invalid shares amount");
 
         // undelegate from non-existing delegation
-        let e = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Undelegate {
@@ -1846,7 +1845,7 @@ mod test {
         )
         .unwrap_err();
         assert_eq!(
-            e.to_string(),
+            error_result.to_string(),
             "no delegation for (address, validator) tuple"
         );
     }
@@ -1862,7 +1861,7 @@ mod test {
         init_balance_denom(&mut env, &delegator_addr_1, 100, "FAKE");
 
         // try to delegate 100 to validator
-        let e = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Delegate {
@@ -1871,9 +1870,8 @@ mod test {
             },
         )
         .unwrap_err();
-
         assert_eq!(
-            e.to_string(),
+            error_result.to_string(),
             "cannot delegate coins of denominator FAKE, only of TOKEN",
         );
     }
@@ -1889,7 +1887,7 @@ mod test {
         init_balance_denom(&mut env, &delegator_addr_1, 100, "FAKE");
 
         // try to delegate 100 to non existing validator
-        let e = env
+        let error_result = env
             .router
             .staking
             .sudo(
@@ -1903,8 +1901,7 @@ mod test {
                 },
             )
             .unwrap_err();
-
-        assert_eq!(e.to_string(), "validator does not exist");
+        assert_eq!(error_result.to_string(), "validator does not exist");
     }
 
     #[test]
@@ -1918,7 +1915,7 @@ mod test {
         init_balance(&mut env, &delegator_addr_1, 100);
 
         // try to delegate
-        let err = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Delegate {
@@ -1927,10 +1924,10 @@ mod test {
             },
         )
         .unwrap_err();
-        assert_eq!(err.to_string(), "validator does not exist");
+        assert_eq!(error_result.to_string(), "validator does not exist");
 
         // try to undelegate
-        let err = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Undelegate {
@@ -1939,7 +1936,7 @@ mod test {
             },
         )
         .unwrap_err();
-        assert_eq!(err.to_string(), "validator does not exist");
+        assert_eq!(error_result.to_string(), "validator does not exist");
     }
 
     #[test]
@@ -1950,7 +1947,7 @@ mod test {
         let delegator_addr_1 = env.delegator_addr_1();
 
         // delegate 0
-        let err = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1.clone(),
             StakingMsg::Delegate {
@@ -1959,10 +1956,10 @@ mod test {
             },
         )
         .unwrap_err();
-        assert_eq!(err.to_string(), "invalid delegation amount");
+        assert_eq!(error_result.to_string(), "invalid delegation amount");
 
         // undelegate 0
-        let err = execute_stake(
+        let error_result = execute_stake(
             &mut env,
             delegator_addr_1,
             StakingMsg::Undelegate {
@@ -1971,7 +1968,7 @@ mod test {
             },
         )
         .unwrap_err();
-        assert_eq!(err.to_string(), "invalid shares amount");
+        assert_eq!(error_result.to_string(), "invalid shares amount");
     }
 
     #[test]

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -154,17 +154,17 @@ pub struct StakeKeeper {
 impl Default for StakeKeeper {
     /// Creates a new stake keeper with default settings.
     fn default() -> Self {
-        Self::new()
+        StakeKeeper {
+            // The address of the staking module. This holds all staked tokens.
+            module_addr: Addr::unchecked("staking_module"),
+        }
     }
 }
 
 impl StakeKeeper {
     /// Creates a new stake keeper with default module address.
     pub fn new() -> Self {
-        StakeKeeper {
-            // The address of the staking module. This holds all staked tokens.
-            module_addr: Addr::unchecked("staking_module"),
-        }
+        Self::default()
     }
 
     /// Provides some general parameters to the stake keeper


### PR DESCRIPTION
- The only functional change is, that `StakeKeeper::new()` calls now `StakeKeeper::default()` (idiomatic Rust).
- Rest of the changes are only in `test` submodule, it is just optimizing/simplifying, unifying test code to be more readable and with less repetitive code. Code coverage stays the same, to be sure that nothing bad happened during this refactoring.