### PR TITLE
Removed `cosmwasm-std` features from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -599,7 +599,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cosmwasm_2_0 = ["cosmwasm_1_4", "cosmwasm-std/cosmwasm_2_0"]
 [dependencies]
 anyhow = "1.0.86"
 bech32 = "0.11.0"
-cosmwasm-std = { version = "2.0.4" }
+cosmwasm-std = "2.0.4"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 derivative = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cosmwasm_2_0 = ["cosmwasm_1_4", "cosmwasm-std/cosmwasm_2_0"]
 [dependencies]
 anyhow = "1.0.86"
 bech32 = "0.11.0"
-cosmwasm-std = { version = "2.0.4", features = ["staking"] }
+cosmwasm-std = { version = "2.0.4" }
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 derivative = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 [features]
 default = []
 backtrace = ["anyhow/backtrace"]
+staking = ["cosmwasm-std/staking"]
 stargate = ["cosmwasm-std/stargate"]
 cosmwasm_1_1 = ["cosmwasm-std/cosmwasm_1_1"]
 cosmwasm_1_2 = ["cosmwasm_1_1", "cosmwasm-std/cosmwasm_1_2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 [features]
 default = []
 backtrace = ["anyhow/backtrace"]
+stargate = ["cosmwasm-std/stargate"]
 cosmwasm_1_1 = ["cosmwasm-std/cosmwasm_1_1"]
 cosmwasm_1_2 = ["cosmwasm_1_1", "cosmwasm-std/cosmwasm_1_2"]
 cosmwasm_1_3 = ["cosmwasm_1_2", "cosmwasm-std/cosmwasm_1_3"]
@@ -23,7 +24,7 @@ cosmwasm_2_0 = ["cosmwasm_1_4", "cosmwasm-std/cosmwasm_2_0"]
 [dependencies]
 anyhow = "1.0.86"
 bech32 = "0.11.0"
-cosmwasm-std = { version = "2.0.4", features = ["staking", "stargate"] }
+cosmwasm-std = { version = "2.0.4", features = ["staking"] }
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 derivative = "2.2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -657,9 +657,12 @@ where
             CosmosMsg::Distribution(msg) => self
                 .distribution
                 .execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "stargate")]
             CosmosMsg::Ibc(msg) => self.ibc.execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "stargate")]
             CosmosMsg::Gov(msg) => self.gov.execute(api, storage, self, block, sender, msg),
             #[allow(deprecated)]
+            #[cfg(feature = "stargate")]
             CosmosMsg::Stargate { type_url, value } => self
                 .stargate
                 .execute_stargate(api, storage, self, block, sender, type_url, value),
@@ -687,8 +690,10 @@ where
             QueryRequest::Bank(req) => self.bank.query(api, storage, &querier, block, req),
             QueryRequest::Custom(req) => self.custom.query(api, storage, &querier, block, req),
             QueryRequest::Staking(req) => self.staking.query(api, storage, &querier, block, req),
+            #[cfg(feature = "stargate")]
             QueryRequest::Ibc(req) => self.ibc.query(api, storage, &querier, block, req),
             #[allow(deprecated)]
+            #[cfg(feature = "stargate")]
             QueryRequest::Stargate { path, data } => self
                 .stargate
                 .query_stargate(api, storage, &querier, block, path, data),

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,13 +2,15 @@ use crate::bank::{Bank, BankKeeper, BankSudo};
 use crate::contracts::Contract;
 use crate::error::{bail, AnyResult};
 use crate::executor::{AppResponse, Executor};
+use crate::featured::staking::{
+    Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo,
+};
 use crate::gov::Gov;
 use crate::ibc::Ibc;
 use crate::module::{FailingModule, Module};
 use crate::prefixed_storage::{
     prefixed, prefixed_multilevel, prefixed_multilevel_read, prefixed_read,
 };
-use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
 use crate::transactions::transactional;
 use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
 use crate::{AppBuilder, GovFailingModule, IbcFailingModule, Stargate, StargateFailing};
@@ -653,7 +655,9 @@ where
             CosmosMsg::Wasm(msg) => self.wasm.execute(api, storage, self, block, sender, msg),
             CosmosMsg::Bank(msg) => self.bank.execute(api, storage, self, block, sender, msg),
             CosmosMsg::Custom(msg) => self.custom.execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "staking")]
             CosmosMsg::Staking(msg) => self.staking.execute(api, storage, self, block, sender, msg),
+            #[cfg(feature = "staking")]
             CosmosMsg::Distribution(msg) => self
                 .distribution
                 .execute(api, storage, self, block, sender, msg),
@@ -689,6 +693,7 @@ where
             QueryRequest::Wasm(req) => self.wasm.query(api, storage, &querier, block, req),
             QueryRequest::Bank(req) => self.bank.query(api, storage, &querier, block, req),
             QueryRequest::Custom(req) => self.custom.query(api, storage, &querier, block, req),
+            #[cfg(feature = "staking")]
             QueryRequest::Staking(req) => self.staking.query(api, storage, &querier, block, req),
             #[cfg(feature = "stargate")]
             QueryRequest::Ibc(req) => self.ibc.query(api, storage, &querier, block, req),
@@ -713,8 +718,9 @@ where
         match msg {
             SudoMsg::Wasm(msg) => self.wasm.sudo(api, storage, self, block, msg),
             SudoMsg::Bank(msg) => self.bank.sudo(api, storage, self, block, msg),
+            #[cfg(feature = "staking")]
             SudoMsg::Staking(msg) => self.staking.sudo(api, storage, self, block, msg),
-            SudoMsg::Custom(_) => unimplemented!(),
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -1,9 +1,9 @@
 //! AppBuilder helps you set up your test blockchain environment step by step [App].
 
+use crate::featured::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking};
 use crate::{
-    App, Bank, BankKeeper, Distribution, DistributionKeeper, FailingModule, Gov, GovFailingModule,
-    Ibc, IbcFailingModule, Module, Router, StakeKeeper, Staking, Stargate, StargateFailing, Wasm,
-    WasmKeeper,
+    App, Bank, BankKeeper, FailingModule, Gov, GovFailingModule, Ibc, IbcFailingModule, Module,
+    Router, Stargate, StargateFailing, Wasm, WasmKeeper,
 };
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_std::{Api, BlockInfo, CustomMsg, CustomQuery, Empty, Storage};

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -430,7 +430,9 @@ where
         msg: match msg.msg {
             CosmosMsg::Wasm(wasm) => CosmosMsg::Wasm(wasm),
             CosmosMsg::Bank(bank) => CosmosMsg::Bank(bank),
+            #[cfg(feature = "staking")]
             CosmosMsg::Staking(staking) => CosmosMsg::Staking(staking),
+            #[cfg(feature = "staking")]
             CosmosMsg::Distribution(distribution) => CosmosMsg::Distribution(distribution),
             CosmosMsg::Custom(_) => unreachable!(),
             #[cfg(feature = "stargate")]

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -433,6 +433,7 @@ where
             CosmosMsg::Staking(staking) => CosmosMsg::Staking(staking),
             CosmosMsg::Distribution(distribution) => CosmosMsg::Distribution(distribution),
             CosmosMsg::Custom(_) => unreachable!(),
+            #[cfg(feature = "stargate")]
             CosmosMsg::Ibc(ibc) => CosmosMsg::Ibc(ibc),
             #[cfg(feature = "cosmwasm_2_0")]
             CosmosMsg::Any(any) => CosmosMsg::Any(any),

--- a/src/featured.rs
+++ b/src/featured.rs
@@ -1,7 +1,43 @@
-//! # Definitions enabled or disabled using crate features
+//! # Definitions enabled or disabled by crate's features
 
 #[cfg(feature = "stargate")]
 pub use cosmwasm_std::GovMsg;
 
 #[cfg(not(feature = "stargate"))]
 pub use cosmwasm_std::Empty as GovMsg;
+
+#[cfg(feature = "staking")]
+pub mod staking {
+    pub use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
+}
+
+#[cfg(not(feature = "staking"))]
+pub mod staking {
+    use crate::error::AnyResult;
+    use crate::{AppResponse, CosmosRouter, FailingModule, Module};
+    use cosmwasm_std::{Api, BlockInfo, CustomMsg, CustomQuery, Empty, Storage};
+
+    pub enum StakingSudo {}
+
+    pub trait Staking: Module<ExecT = Empty, QueryT = Empty, SudoT = Empty> {
+        fn process_queue<ExecC: CustomMsg, QueryC: CustomQuery>(
+            &self,
+            _api: &dyn Api,
+            _storage: &mut dyn Storage,
+            _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+            _block: &BlockInfo,
+        ) -> AnyResult<AppResponse> {
+            Ok(AppResponse::default())
+        }
+    }
+
+    pub type StakeKeeper = FailingModule<Empty, Empty, Empty>;
+
+    impl Staking for StakeKeeper {}
+
+    pub trait Distribution: Module<ExecT = Empty, QueryT = Empty, SudoT = Empty> {}
+
+    pub type DistributionKeeper = FailingModule<Empty, Empty, Empty>;
+
+    impl Distribution for DistributionKeeper {}
+}

--- a/src/featured.rs
+++ b/src/featured.rs
@@ -1,0 +1,7 @@
+//! # Definitions enabled or disabled using crate features
+
+#[cfg(feature = "stargate")]
+pub use cosmwasm_std::GovMsg;
+
+#[cfg(not(feature = "stargate"))]
+pub use cosmwasm_std::Empty as GovMsg;

--- a/src/gov.rs
+++ b/src/gov.rs
@@ -1,15 +1,19 @@
+use crate::featured::GovMsg;
 use crate::{AcceptingModule, FailingModule, Module};
-use cosmwasm_std::{Empty, GovMsg};
+use cosmwasm_std::Empty;
+
 /// Handles governance-related operations within the test environment.
 /// This trait is essential for testing contracts that interact with governance mechanisms,
 /// simulating proposals, voting, and other governance activities.
 pub trait Gov: Module<ExecT = GovMsg, QueryT = Empty, SudoT = Empty> {}
+
 /// A type alias for a module that accepts governance-related interactions.
 /// It's used in scenarios where you need to test how your contract interacts
 /// with governance processes and messages.
 pub type GovAcceptingModule = AcceptingModule<GovMsg, Empty, Empty>;
 
 impl Gov for GovAcceptingModule {}
+
 /// This type alias represents a module designed to fail in response to governance operations.
 /// It's useful for testing how contracts behave when governance actions do not proceed as expected.
 pub type GovFailingModule = FailingModule<GovMsg, Empty, Empty>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ mod contracts;
 pub mod custom_handler;
 pub mod error;
 mod executor;
+mod featured;
 mod gov;
 mod ibc;
 mod module;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ mod gov;
 mod ibc;
 mod module;
 mod prefixed_storage;
+#[cfg(feature = "staking")]
 mod staking;
 mod stargate;
 mod test_helpers;
@@ -161,6 +162,7 @@ pub use crate::executor::{AppResponse, Executor};
 pub use crate::gov::{Gov, GovAcceptingModule, GovFailingModule};
 pub use crate::ibc::{Ibc, IbcAcceptingModule, IbcFailingModule};
 pub use crate::module::{AcceptingModule, FailingModule, Module};
+#[cfg(feature = "staking")]
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -8,11 +8,14 @@ use serde::{Deserialize, Serialize};
 pub mod caller;
 pub mod echo;
 pub mod error;
+#[cfg(feature = "stargate")]
 pub mod gov;
 pub mod hackatom;
+#[cfg(feature = "stargate")]
 pub mod ibc;
 pub mod payout;
 pub mod reflect;
+#[cfg(feature = "stargate")]
 pub mod stargate;
 
 /// Custom message for testing purposes.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,9 @@
 mod test_app;
 mod test_custom_handler;
 mod test_error;
+#[cfg(feature = "stargate")]
 mod test_gov;
+#[cfg(feature = "stargate")]
 mod test_ibc;
+#[cfg(feature = "stargate")]
 mod test_stargate;

--- a/src/tests/test_app.rs
+++ b/src/tests/test_app.rs
@@ -1,12 +1,13 @@
 use crate::custom_handler::CachingCustomHandler;
 use crate::error::{bail, AnyResult};
+use crate::featured::staking::{Distribution, Staking};
 use crate::test_helpers::echo::EXECUTE_REPLY_BASE_ID;
 use crate::test_helpers::{caller, echo, error, hackatom, payout, reflect, CustomHelperMsg};
 use crate::transactions::{transactional, StorageTransaction};
 use crate::wasm::ContractData;
 use crate::{
-    custom_app, next_block, no_init, App, AppResponse, Bank, CosmosRouter, Distribution, Executor,
-    Module, Router, Staking, Wasm, WasmSudo,
+    custom_app, next_block, no_init, App, AppResponse, Bank, CosmosRouter, Executor, Module,
+    Router, Wasm, WasmSudo,
 };
 use crate::{AppBuilder, IntoAddr};
 use cosmwasm_std::testing::{mock_env, MockQuerier};

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1254,8 +1254,8 @@ mod test {
     use super::*;
     use crate::app::Router;
     use crate::bank::BankKeeper;
+    use crate::featured::staking::{DistributionKeeper, StakeKeeper};
     use crate::module::FailingModule;
-    use crate::staking::{DistributionKeeper, StakeKeeper};
     use crate::test_helpers::{caller, error, payout};
     use crate::transactions::StorageTransaction;
     use crate::{GovFailingModule, IbcFailingModule, StargateFailing};

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -8,6 +8,7 @@ mod test_bank;
 mod test_contract_storage;
 mod test_module;
 mod test_prefixed_storage;
+#[cfg(feature = "staking")]
 mod test_staking;
 mod test_wasm;
 

--- a/tests/test_app_builder/mod.rs
+++ b/tests/test_app_builder/mod.rs
@@ -9,9 +9,12 @@ mod test_with_api;
 mod test_with_bank;
 mod test_with_block;
 mod test_with_distribution;
+#[cfg(feature = "stargate")]
 mod test_with_gov;
+#[cfg(feature = "stargate")]
 mod test_with_ibc;
 mod test_with_staking;
+#[cfg(feature = "stargate")]
 mod test_with_stargate;
 mod test_with_storage;
 #[cfg(feature = "cosmwasm_1_2")]

--- a/tests/test_app_builder/mod.rs
+++ b/tests/test_app_builder/mod.rs
@@ -8,19 +8,19 @@ use std::marker::PhantomData;
 mod test_with_api;
 mod test_with_bank;
 mod test_with_block;
+#[cfg(feature = "staking")]
 mod test_with_distribution;
 #[cfg(feature = "stargate")]
 mod test_with_gov;
 #[cfg(feature = "stargate")]
 mod test_with_ibc;
+#[cfg(feature = "staking")]
 mod test_with_staking;
 #[cfg(feature = "stargate")]
 mod test_with_stargate;
 mod test_with_storage;
 #[cfg(feature = "cosmwasm_1_2")]
 mod test_with_wasm;
-
-const NO_MESSAGE: &str = "";
 
 struct MyKeeper<ExecT, QueryT, SudoT>(
     PhantomData<(ExecT, QueryT, SudoT)>,

--- a/tests/test_app_builder/test_with_distribution.rs
+++ b/tests/test_app_builder/test_with_distribution.rs
@@ -1,4 +1,4 @@
-use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
+use crate::test_app_builder::MyKeeper;
 use cosmwasm_std::{DistributionMsg, Empty};
 use cw_multi_test::{no_init, AppBuilder, Distribution, Executor};
 
@@ -12,7 +12,7 @@ const EXECUTE_MSG: &str = "distribution execute called";
 fn building_app_with_custom_distribution_should_work() {
     // build custom distribution keeper
     // which has no query or sudo messages
-    let distribution_keeper = MyDistributionKeeper::new(EXECUTE_MSG, NO_MESSAGE, NO_MESSAGE);
+    let distribution_keeper = MyDistributionKeeper::new(EXECUTE_MSG, "", "");
 
     // build the application with custom distribution keeper
     let app_builder = AppBuilder::default();

--- a/tests/test_app_builder/test_with_gov.rs
+++ b/tests/test_app_builder/test_with_gov.rs
@@ -1,4 +1,4 @@
-use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
+use crate::test_app_builder::MyKeeper;
 use cosmwasm_std::{Empty, GovMsg, VoteOption};
 use cw_multi_test::{no_init, AppBuilder, Executor, Gov};
 
@@ -11,7 +11,7 @@ const EXECUTE_MSG: &str = "gov execute called";
 #[test]
 fn building_app_with_custom_gov_should_work() {
     // build custom governance keeper (no query and sudo handling for gov module)
-    let gov_keeper = MyGovKeeper::new(EXECUTE_MSG, NO_MESSAGE, NO_MESSAGE);
+    let gov_keeper = MyGovKeeper::new(EXECUTE_MSG, "", "");
 
     // build the application with custom gov keeper
     let mut app = AppBuilder::default().with_gov(gov_keeper).build(no_init);

--- a/tests/test_app_builder/test_with_ibc.rs
+++ b/tests/test_app_builder/test_with_ibc.rs
@@ -1,4 +1,4 @@
-use crate::test_app_builder::{MyKeeper, NO_MESSAGE};
+use crate::test_app_builder::MyKeeper;
 use cosmwasm_std::{Empty, IbcMsg, IbcQuery, QueryRequest};
 use cw_multi_test::{no_init, AppBuilder, Executor, Ibc};
 
@@ -12,7 +12,7 @@ const QUERY_MSG: &str = "ibc query called";
 #[test]
 fn building_app_with_custom_ibc_should_work() {
     // build custom ibc keeper (no sudo handling for ibc)
-    let ibc_keeper = MyIbcKeeper::new(EXECUTE_MSG, QUERY_MSG, NO_MESSAGE);
+    let ibc_keeper = MyIbcKeeper::new(EXECUTE_MSG, QUERY_MSG, "");
 
     // build the application with custom ibc keeper
     let mut app = AppBuilder::default().with_ibc(ibc_keeper).build(no_init);

--- a/tests/test_app_builder/test_with_stargate.rs
+++ b/tests/test_app_builder/test_with_stargate.rs
@@ -206,6 +206,7 @@ fn building_app_with_accepting_any_grpc_should_work() {
 }
 
 #[test]
+#[cfg(feature = "stargate")]
 fn default_failing_stargate_should_work() {
     let app_builder = AppBuilder::default();
     let mut app = app_builder.with_stargate(StargateFailing).build(no_init);


### PR DESCRIPTION
- Removed all features from `cosmwasm-std` dependency in **MultiTest**.
- Added **MultiTest** feature **staking** that enables the same feature in `cosmwasm-std`.
- Added **MultiTest** feature **stargate** that enables the same feature in `cosmwasm-std`.
- Adjusted code base to compile with any combination of features.