### PR TITLE
Upgraded dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
   coverage:
     # https://circleci.com/developer/images?imageType=machine
     machine:
-      image: ubuntu-2204:2024.01.1
+      image: ubuntu-2404:2024.05.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           name: Run tests with coverage
           command: |
             mkdir -p cov
-            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.31.1 \
+            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.31.0 \
               sh -c "cargo tarpaulin --workspace --all-features --force-clean --engine llvm --out xml --output-dir cov"
       - codecov/upload:
           file: cov/cobertura.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ jobs:
       - run:
           name: Version information
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
-      - run:
-          name: Remove Cargo.lock
-          command: rm Cargo.lock
+      #      - run:
+      #          name: Remove Cargo.lock
+      #          command: rm Cargo.lock
       - restore_cache:
           keys:
             - cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,15 +59,19 @@ jobs:
   build_minimal:
     docker:
       - image: rustlang/rust:nightly
-    working_directory: ~/project/
+    working_directory: ~/project
     steps:
       - checkout
       - run:
           name: Version information
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
-      #      - run:
-      #          name: Remove Cargo.lock
-      #          command: rm Cargo.lock
+      - run:
+          name: Remove Cargo.lock
+          command: rm Cargo.lock
+      #  Remove the following command after upgrading dependencies in crates ahash and num-bigint
+      - run:
+          name: Temporarily update problematic crates
+          command: cargo update -p ahash && cargo update -p num-bigint
       - restore_cache:
           keys:
             - cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}
@@ -86,7 +90,7 @@ jobs:
   build_maximal:
     docker:
       - image: rust:1.75
-    working_directory: ~/project/
+    working_directory: ~/project
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Remove Cargo.lock
           command: rm Cargo.lock
-      #  Remove the following command after upgrading dependencies in crates ahash and num-bigint
+      #  Remove the following command after dependencies in crates ahash and num-bigint are upgraded!
       - run:
           name: Temporarily update problematic crates
           command: cargo update -p ahash && cargo update -p num-bigint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           command: rm Cargo.lock
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.75-{{ checksum "Cargo.toml" }}
+            - cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
 jobs:
   build_and_test:
     docker:
-      - image: rust:1.70
+      - image: rust:1.75
     working_directory: ~/project
     steps:
       - checkout
@@ -42,8 +42,8 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.70-{{ checksum "Cargo.lock" }}
-            - cargocache-v2-multi-test:1.70-
+            - cargocache-v2-multi-test:1.75-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-multi-test:1.75-
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -54,7 +54,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.70-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.75-{{ checksum "Cargo.lock" }}
 
   build_minimal:
     docker:
@@ -70,7 +70,7 @@ jobs:
           command: rm Cargo.lock
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.70-minimal-{{ checksum "Cargo.toml" }}
+            - cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features
@@ -81,11 +81,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.70-minimal-{{ checksum "Cargo.toml" }}
+          key: cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}
 
   build_maximal:
     docker:
-      - image: rust:1.70
+      - image: rust:1.75
     working_directory: ~/project/
     steps:
       - checkout
@@ -97,7 +97,7 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.70-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-multi-test:1.75-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked --all-features
@@ -108,11 +108,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.70-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.75-{{ checksum "Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.70
+      - image: rust:1.75
     steps:
       - checkout
       - run:
@@ -123,8 +123,8 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.70-{{ checksum "Cargo.lock" }}
-            - cargocache-v2-lint-rust:1.70-
+            - cargocache-v2-lint-rust:1.75-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.75-
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -143,7 +143,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.70-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.75-{{ checksum "Cargo.lock" }}
 
   coverage:
     # https://circleci.com/developer/images?imageType=machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           name: Run tests with coverage
           command: |
             mkdir -p cov
-            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.27.1 \
+            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.31.1 \
               sh -c "cargo tarpaulin --workspace --all-features --force-clean --engine llvm --out xml --output-dir cov"
       - codecov/upload:
           file: cov/cobertura.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           command: rm Cargo.lock
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.75-minimal-{{ checksum "Cargo.toml" }}
+            - cargocache-v2-multi-test:1.75-{{ checksum "Cargo.toml" }}
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,21 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anyhow"
@@ -36,6 +43,133 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -60,36 +194,15 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -102,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "byteorder"
@@ -114,15 +227,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -137,32 +250,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "cosmwasm-crypto"
-version = "2.0.4"
+name = "cosmwasm-core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a339f6b59ff7ad4ae05a70512a4f3c19bf8fcc845d46bfef90f4ec0810f72c"
+checksum = "367fc87c43759098a476ef90f915aadc66c300480ad9c155b512081fbf327bc1"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7c41f3e371ea457d3b98bb592c38858b46efcf614e0e988ec2ebbdb973954f"
 dependencies = [
- "digest 0.10.7",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
+ "digest",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.4",
+ "num-traits",
+ "p256",
+ "rand_core",
+ "rayon",
+ "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3bfea6af94a83880fb05478135ed0c256d9a2fcde58c595a10d64dcb9c925d"
+checksum = "c10510e8eb66cf7e109741b1e2c76ad18f30b5a1daa064f5f7115c1f733aaea0"
 dependencies = [
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101d0739564bd34cba9b84bf73665f0822487ae3b29b2dd59930608ed3aafd43"
+checksum = "f79879b6b7ef6a331b05030ce91ce46a7c4b0baf1ed6b382cce2e9a168109380"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -173,33 +304,34 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4be75f60158478da2c5d319ed59295bca1687ad50c18215a0485aa91a995ea"
+checksum = "82b53e33c0e97170c7ac9cb440f4bc599a07f9cbb9b7e87916cca37b1239d57b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "2.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded932165de44cd0717979c34fc3b84d8e8066b8dde4f5bd78f96a643b090f90"
+checksum = "92011c39570876f340d5f9defa68bf92797b1c44421f1b9ea9b04a31d6defd33"
 dependencies = [
  "base64",
- "bech32 0.9.1",
+ "bech32",
  "bnum",
+ "cosmwasm-core",
  "cosmwasm-crypto",
  "cosmwasm-derive",
- "derivative",
- "forward_ref",
+ "derive_more",
  "hex",
+ "rand_core",
  "schemars",
  "serde",
  "serde-json-wasm",
- "sha2 0.10.8",
+ "sha2",
  "static_assertions",
  "thiserror",
 ]
@@ -214,13 +346,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -237,15 +394,29 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -253,19 +424,19 @@ name = "cw-multi-test"
 version = "2.1.0"
 dependencies = [
  "anyhow",
- "bech32 0.11.0",
+ "bech32",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw-utils",
  "derivative",
  "hex",
  "hex-literal",
- "itertools",
+ "itertools 0.13.0",
  "once_cell",
  "prost",
  "schemars",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
 ]
 
@@ -315,12 +486,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.9.0"
+name = "derive_more"
+version = "1.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "3249c0372e72f5f93b5c0ca54c0ab76bbf6216b6f718925476fd9bc4ffabb4fe"
 dependencies = [
- "generic-array",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d919ced7590fc17b5d5a3c63b662e8a7d2324212c4e4dbbed975cafd22d16d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -329,7 +512,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -348,25 +531,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
- "hashbrown",
+ "ed25519",
+ "hashbrown 0.14.5",
  "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.9.9",
+ "rand_core",
+ "sha2",
  "zeroize",
 ]
 
@@ -384,12 +575,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -401,15 +591,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
-name = "forward_ref"
-version = "1.0.0"
+name = "fiat-crypto"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "generic-array"
@@ -446,17 +636,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -477,7 +677,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -504,9 +713,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.8",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -531,10 +738,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.1"
+name = "num-bigint"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -546,19 +781,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
+name = "p256"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "der",
- "spki",
+ "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -587,10 +842,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -603,10 +858,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.5.1"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -615,6 +884,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -632,6 +921,15 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "ryu"
@@ -660,7 +958,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -672,10 +970,15 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -703,7 +1006,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -714,31 +1017,19 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -749,7 +1040,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -758,18 +1049,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -797,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -808,22 +1089,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -839,10 +1120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "unicode-xid"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -851,7 +1138,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cosmwasm_2_0 = ["cosmwasm_1_4", "cosmwasm-std/cosmwasm_2_0"]
 [dependencies]
 anyhow = "1.0.86"
 bech32 = "0.11.0"
-cosmwasm-std = "2.0.4"
+cosmwasm-std = "2.1.1"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 derivative = "2.2.0"
@@ -34,7 +34,7 @@ prost = "0.13.1"
 schemars = "0.8.21"
 serde = "1.0.204"
 sha2 = "0.10.8"
-thiserror = "1.0.61"
+thiserror = "1.0.63"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/tests/test_api/test_prefixed.rs
+++ b/tests/test_api/test_prefixed.rs
@@ -68,7 +68,7 @@ fn debug_should_not_panic() {
 }
 
 #[test]
-#[should_panic(expected = "Generating address failed with reason: invalid length")]
+#[should_panic]
 fn address_make_prefix_too_long() {
     api_prefix(
         "juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_juno_",


### PR DESCRIPTION
Upgraded `cosmasm-std` to version **2.1.1**
After this upgrade, building MultiTest with minimal versions of dependencies failed on CI.
The same effect can be reproduced locally, by doing this:
```shell
cargo clean
rm -rf Cargo.lock
cargo +nightly build -Zminimal-versions --all-features
```
Running `cargo tree` just after above commands shows awkward dependencies:
```text
│   ├── cosmwasm-crypto v2.1.1
│   │   ├── ark-bls12-381 v0.4.0
│   │   │   ├── ark-ec v0.4.2
│   │   │   │   ├── ark-ff v0.4.2
│   │   │   │   │   ├── ark-ff-asm v0.4.2-alpha.1 (proc-macro)
│   │   │   │   │   │   ├── quote v1.0.35
│   │   │   │   │   │   │   └── proc-macro2 v1.0.79
│   │   │   │   │   │   │       └── unicode-ident v1.0.0
│   │   │   │   │   │   └── syn v1.0.3
│   │   │   │   │   │       ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │       ├── quote v1.0.35 (*)
│   │   │   │   │   │       └── unicode-xid v0.2.2
│   │   │   │   │   ├── ark-ff-macros v0.4.2-alpha.1 (proc-macro)
│   │   │   │   │   │   ├── num-bigint v0.4.0
│   │   │   │   │   │   │   ├── num-integer v0.1.42
│   │   │   │   │   │   │   │   └── num-traits v0.2.18
│   │   │   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │   │   │       └── autocfg v1.0.0
│   │   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   │   └── autocfg v1.0.0
│   │   │   │   │   │   │   └── num-traits v0.2.18 (*)
│   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   └── autocfg v1.0.0
│   │   │   │   │   │   ├── num-traits v0.2.18 (*)
│   │   │   │   │   │   ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │   ├── quote v1.0.35 (*)
│   │   │   │   │   │   └── syn v1.0.3 (*)
│   │   │   │   │   ├── ark-serialize v0.4.2
│   │   │   │   │   │   ├── ark-serialize-derive v0.4.2-alpha.1 (proc-macro)
│   │   │   │   │   │   │   ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │   │   ├── quote v1.0.35 (*)
│   │   │   │   │   │   │   └── syn v1.0.3 (*)
│   │   │   │   │   │   ├── ark-std v0.4.0
│   │   │   │   │   │   │   ├── num-traits v0.2.18
│   │   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   │   └── autocfg v1.0.0
│   │   │   │   │   │   │   ├── rand v0.8.0
│   │   │   │   │   │   │   │   ├── rand_chacha v0.3.0
│   │   │   │   │   │   │   │   │   ├── ppv-lite86 v0.2.8
│   │   │   │   │   │   │   │   │   └── rand_core v0.6.4
│   │   │   │   │   │   │   │   │       └── getrandom v0.2.0
│   │   │   │   │   │   │   │   │           ├── cfg-if v0.1.2
│   │   │   │   │   │   │   │   │           └── libc v0.2.95
│   │   │   │   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   │   │   │   └── rayon v1.9.0
│   │   │   │   │   │   │       ├── either v1.0.0
│   │   │   │   │   │   │       └── rayon-core v1.12.1
│   │   │   │   │   │   │           ├── crossbeam-deque v0.8.1
│   │   │   │   │   │   │           │   ├── cfg-if v1.0.0
│   │   │   │   │   │   │           │   ├── crossbeam-epoch v0.9.5
│   │   │   │   │   │   │           │   │   ├── cfg-if v1.0.0
│   │   │   │   │   │   │           │   │   ├── crossbeam-utils v0.8.7
│   │   │   │   │   │   │           │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   │   │           │   │   │   └── lazy_static v1.4.0
│   │   │   │   │   │   │           │   │   ├── lazy_static v1.4.0
│   │   │   │   │   │   │           │   │   ├── memoffset v0.6.1
│   │   │   │   │   │   │           │   │   │   [build-dependencies]
│   │   │   │   │   │   │           │   │   │   └── autocfg v1.0.0
│   │   │   │   │   │   │           │   │   └── scopeguard v1.1.0
│   │   │   │   │   │   │           │   └── crossbeam-utils v0.8.7 (*)
│   │   │   │   │   │   │           └── crossbeam-utils v0.8.7 (*)
│   │   │   │   │   │   ├── digest v0.10.7
│   │   │   │   │   │   │   ├── block-buffer v0.10.1
│   │   │   │   │   │   │   │   └── generic-array v0.14.6
│   │   │   │   │   │   │   │       ├── typenum v1.14.0
│   │   │   │   │   │   │   │       └── zeroize v1.7.0
│   │   │   │   │   │   │   │           └── zeroize_derive v1.3.2 (proc-macro)
│   │   │   │   │   │   │   │               ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │   │   │               ├── quote v1.0.35 (*)
│   │   │   │   │   │   │   │               ├── syn v1.0.3 (*)
│   │   │   │   │   │   │   │               └── synstructure v0.12.2
│   │   │   │   │   │   │   │                   ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │   │   │                   ├── quote v1.0.35 (*)
│   │   │   │   │   │   │   │                   ├── syn v1.0.3 (*)
│   │   │   │   │   │   │   │                   └── unicode-xid v0.2.2
│   │   │   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │   │   │       └── version_check v0.9.4
│   │   │   │   │   │   │   ├── const-oid v0.9.2
│   │   │   │   │   │   │   ├── crypto-common v0.1.3
│   │   │   │   │   │   │   │   ├── generic-array v0.14.6 (*)
│   │   │   │   │   │   │   │   └── typenum v1.14.0
│   │   │   │   │   │   │   └── subtle v2.4.0
│   │   │   │   │   │   └── num-bigint v0.4.0 (*)
│   │   │   │   │   ├── ark-std v0.4.0 (*)
│   │   │   │   │   ├── derivative v2.2.0 (proc-macro)
│   │   │   │   │   │   ├── proc-macro2 v1.0.79 (*)
│   │   │   │   │   │   ├── quote v1.0.35 (*)
│   │   │   │   │   │   └── syn v1.0.3 (*)
│   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   ├── itertools v0.10.0
│   │   │   │   │   │   └── either v1.0.0
│   │   │   │   │   ├── num-bigint v0.4.0 (*)
│   │   │   │   │   ├── num-traits v0.2.18 (*)
│   │   │   │   │   ├── paste v1.0.0 (proc-macro)
│   │   │   │   │   ├── rayon v1.9.0 (*)
│   │   │   │   │   └── zeroize v1.7.0 (*)
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── rustc_version v0.4.0
│   │   │   │   │       └── semver v1.0.0
│   │   │   │   ├── ark-poly v0.4.2-alpha.1
│   │   │   │   │   ├── ark-ff v0.4.2 (*)
│   │   │   │   │   ├── ark-serialize v0.4.2 (*)
│   │   │   │   │   ├── ark-std v0.4.0 (*)
│   │   │   │   │   ├── derivative v2.2.0 (proc-macro) (*)
│   │   │   │   │   └── hashbrown v0.13.1
│   │   │   │   │       └── ahash v0.8.4 <---------- HERE !!!
```

Result:
```text
   Compiling cpufeatures v0.2.6
error[E0635]: unknown feature `stdsimd`
  --> /home/confio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.4/src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^

   Compiling quote v1.0.35
For more information about this error, try `rustc --explain E0635`.
error: could not compile `ahash` (lib) due to 1 previous error
```
The above problem was solved in version **0.8.7** of `ahash`, but pinning its version in Cargo.toml in MultiTest raises even more problems:

```text
error[E0308]: mismatched types
    --> /home/confio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/num-bigint-0.4.0/src/biguint/convert.rs:70:19
     |
70   |         .div_ceil(&big_digit::BITS.into())
     |          -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `&_`
     |          |
     |          arguments to this method are incorrect
     |
     = note:   expected type `u64`
             found reference `&_`
note: method defined here
    --> /home/confio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/mod.rs:1159:5
     |
1159 | /     uint_impl! {
1160 | |         Self = u64,
1161 | |         ActualT = u64,
1162 | |         SignedT = i64,
...    |
1176 | |         bound_condition = "",
1177 | |     }
     | |_____^
     = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider removing the borrow
     |
70   -         .div_ceil(&big_digit::BITS.into())
70   +         .div_ceil(big_digit::BITS.into())
     |

error[E0308]: mismatched types
    --> /home/confio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/num-bigint-0.4.0/src/biguint/convert.rs:585:19
     |
585  |         .div_ceil(&u64::from(bits))
     |          -------- ^^^^^^^^^^^^^^^^ expected `u64`, found `&u64`
     |          |
     |          arguments to this method are incorrect
     |
note: method defined here
    --> /home/confio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/mod.rs:1159:5
     |
1159 | /     uint_impl! {
1160 | |         Self = u64,
1161 | |         ActualT = u64,
1162 | |         SignedT = i64,
...    |
1176 | |         bound_condition = "",
1177 | |     }
     | |_____^
     = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider removing the borrow
     |
585  -         .div_ceil(&u64::from(bits))
585  +         .div_ceil(u64::from(bits))
     |

error[E0308]: mismatched types
    --> /home/confio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/num-bigint-0.4.0/src/biguint/convert.rs:613:19
     |
613  |         .div_ceil(&u64::from(bits))
     |          -------- ^^^^^^^^^^^^^^^^ expected `u64`, found `&u64`
     |          |
     |          arguments to this method are incorrect
     |
note: method defined here
    --> /home/confio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/mod.rs:1159:5
     |
1159 | /     uint_impl! {
1160 | |         Self = u64,
1161 | |         ActualT = u64,
1162 | |         SignedT = i64,
...    |
1176 | |         bound_condition = "",
1177 | |     }
     | |_____^
     = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider removing the borrow
     |
613  -         .div_ceil(&u64::from(bits))
613  +         .div_ceil(u64::from(bits))
     |
```