### PR TITLE
Removed `derivative` crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cfg-if"
@@ -245,15 +245,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-core"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d905990ef3afb5753bb709dc7de88e9e370aa32bcc2f31731d4b533b63e82490"
+checksum = "5f6ceb8624260d0d3a67c4e1a1d43fc7e9406720afbcb124521501dd138f90aa"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2a7bd9c1dd9a377a4dc0f4ad97d24b03c33798cd5a6d7ceb8869b41c5d2f2d"
+checksum = "4125381e5fd7fefe9f614640049648088015eca2b60d861465329a5d87dfa538"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029910b409398fdf81955d7301b906caf81f2c42b013ea074fbd89720229c424"
+checksum = "1b5658b1dc64e10b56ae7a449f678f96932a96f6cfad1769d608d1d1d656480a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc0d4d85e83438ab9a0fea9348446f7268bc016aacfebce37e998559f151294"
+checksum = "f86b4d949b6041519c58993a73f4bbfba8083ba14f7001eae704865a09065845"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf5c8adac41bb7751c050d7c4c18675be19ee128714454454575e894424eeef"
+checksum = "c8ef1b5835a65fcca3ab8b9a02b4f4dacc78e233a5c2f20b270efb9db0666d12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dec99a2e478715c0a4277f0dbeadbb8466500eb7dec873d0924edd086e77f1"
+checksum = "70eb7ab0c1e99dd6207496963ba2a457c4128ac9ad9c72a83f8d9808542b849b"
 dependencies = [
  "base64",
  "bech32",
@@ -422,7 +422,6 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw-utils",
- "derivative",
  "hex",
  "hex-literal",
  "itertools 0.13.0",
@@ -700,9 +699,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -821,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -831,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -1083,18 +1082,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1115,9 +1114,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,15 @@ cosmwasm_2_1 = ["cosmwasm_2_0", "cosmwasm-std/cosmwasm_2_1"]
 [dependencies]
 anyhow = "1.0.89"
 bech32 = "0.11.0"
-cosmwasm-std = "2.1.3"
+cosmwasm-std = "2.1.4"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
-derivative = "2.2.0"
 itertools = "0.13.0"
-prost = "0.13.2"
+prost = "0.13.3"
 schemars = "0.8.21"
 serde = "1.0.210"
 sha2 = "0.10.8"
-thiserror = "1.0.63"
+thiserror = "1.0.64"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/custom_handler.rs
+++ b/src/custom_handler.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 #[derive(Default, Clone)]
 pub struct CachingCustomHandlerState<ExecC, QueryC>
 where
-    ExecC: Clone,
-    QueryC: Clone,
+    ExecC: Default + Clone,
+    QueryC: Default + Clone,
 {
     /// Cache for processes custom messages.
     execs: Rc<RefCell<Vec<ExecC>>>,
@@ -23,15 +23,12 @@ where
 
 impl<ExecC, QueryC> CachingCustomHandlerState<ExecC, QueryC>
 where
-    ExecC: Clone,
-    QueryC: Clone,
+    ExecC: Default + Clone,
+    QueryC: Default + Clone,
 {
     /// Creates a new [CachingCustomHandlerState].
     pub fn new() -> Self {
-        Self {
-            execs: Rc::new(RefCell::new(vec![])),
-            queries: Rc::new(RefCell::new(vec![])),
-        }
+        Default::default()
     }
 
     /// Returns a slice of processed custom messages.
@@ -57,8 +54,8 @@ where
 #[derive(Default, Clone)]
 pub struct CachingCustomHandler<ExecC, QueryC>
 where
-    ExecC: Clone,
-    QueryC: Clone,
+    ExecC: Default + Clone,
+    QueryC: Default + Clone,
 {
     /// Cached state.
     state: CachingCustomHandlerState<ExecC, QueryC>,
@@ -66,14 +63,12 @@ where
 
 impl<ExecC, QueryC> CachingCustomHandler<ExecC, QueryC>
 where
-    ExecC: Clone,
-    QueryC: Clone,
+    ExecC: Default + Clone,
+    QueryC: Default + Clone,
 {
     /// Creates a new [CachingCustomHandler].
     pub fn new() -> Self {
-        Self {
-            state: CachingCustomHandlerState::new(),
-        }
+        Default::default()
     }
 
     /// Returns the cached state.
@@ -84,8 +79,8 @@ where
 
 impl<Exec, Query> Module for CachingCustomHandler<Exec, Query>
 where
-    Exec: Clone,
-    Query: Clone,
+    Exec: Default + Clone,
+    Query: Default + Clone,
 {
     type ExecT = Exec;
     type QueryT = Query;

--- a/src/custom_handler.rs
+++ b/src/custom_handler.rs
@@ -26,6 +26,14 @@ where
     ExecC: Clone,
     QueryC: Clone,
 {
+    /// Creates a new [CachingCustomHandlerState].
+    pub fn new() -> Self {
+        Self {
+            execs: Rc::new(RefCell::new(vec![])),
+            queries: Rc::new(RefCell::new(vec![])),
+        }
+    }
+
     /// Returns a slice of processed custom messages.
     pub fn execs(&self) -> impl Deref<Target = [ExecC]> + '_ {
         Ref::map(self.execs.borrow(), Vec::as_slice)
@@ -61,6 +69,13 @@ where
     ExecC: Clone,
     QueryC: Clone,
 {
+    /// Creates a new [CachingCustomHandler].
+    pub fn new() -> Self {
+        Self {
+            state: CachingCustomHandlerState::new(),
+        }
+    }
+
     /// Returns the cached state.
     pub fn state(&self) -> CachingCustomHandlerState<ExecC, QueryC> {
         self.state.clone()

--- a/src/custom_handler.rs
+++ b/src/custom_handler.rs
@@ -4,22 +4,28 @@ use crate::app::CosmosRouter;
 use crate::error::{bail, AnyResult};
 use crate::{AppResponse, Module};
 use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Empty, Querier, Storage};
-use derivative::Derivative;
 use std::cell::{Ref, RefCell};
 use std::ops::Deref;
 use std::rc::Rc;
 
 /// A cache for messages and queries processes by the custom module.
-#[derive(Derivative)]
-#[derivative(Default(bound = "", new = "true"), Clone(bound = ""))]
-pub struct CachingCustomHandlerState<ExecC, QueryC> {
+#[derive(Default, Clone)]
+pub struct CachingCustomHandlerState<ExecC, QueryC>
+where
+    ExecC: Clone,
+    QueryC: Clone,
+{
     /// Cache for processes custom messages.
     execs: Rc<RefCell<Vec<ExecC>>>,
     /// Cache for processed custom queries.
     queries: Rc<RefCell<Vec<QueryC>>>,
 }
 
-impl<ExecC, QueryC> CachingCustomHandlerState<ExecC, QueryC> {
+impl<ExecC, QueryC> CachingCustomHandlerState<ExecC, QueryC>
+where
+    ExecC: Clone,
+    QueryC: Clone,
+{
     /// Returns a slice of processed custom messages.
     pub fn execs(&self) -> impl Deref<Target = [ExecC]> + '_ {
         Ref::map(self.execs.borrow(), Vec::as_slice)
@@ -40,26 +46,36 @@ impl<ExecC, QueryC> CachingCustomHandlerState<ExecC, QueryC> {
 /// Custom handler that stores all received messages and queries.
 ///
 /// State is thin shared state, so it can be held after mock is passed to [App](crate::App) to read state.
-#[derive(Clone, Derivative)]
-#[derivative(Default(bound = "", new = "true"))]
-pub struct CachingCustomHandler<ExecC, QueryC> {
+#[derive(Default, Clone)]
+pub struct CachingCustomHandler<ExecC, QueryC>
+where
+    ExecC: Clone,
+    QueryC: Clone,
+{
     /// Cached state.
     state: CachingCustomHandlerState<ExecC, QueryC>,
 }
 
-impl<ExecC, QueryC> CachingCustomHandler<ExecC, QueryC> {
+impl<ExecC, QueryC> CachingCustomHandler<ExecC, QueryC>
+where
+    ExecC: Clone,
+    QueryC: Clone,
+{
     /// Returns the cached state.
     pub fn state(&self) -> CachingCustomHandlerState<ExecC, QueryC> {
         self.state.clone()
     }
 }
 
-impl<Exec, Query> Module for CachingCustomHandler<Exec, Query> {
+impl<Exec, Query> Module for CachingCustomHandler<Exec, Query>
+where
+    Exec: Clone,
+    Query: Clone,
+{
     type ExecT = Exec;
     type QueryT = Query;
     type SudoT = Empty;
 
-    // TODO: how to assert like `where ExecC: Exec, QueryC: Query`
     fn execute<ExecC, QueryC>(
         &self,
         _api: &dyn Api,

--- a/src/test_helpers/echo.rs
+++ b/src/test_helpers/echo.rs
@@ -9,7 +9,6 @@ use cosmwasm_std::{
     Reply, Response, StdError, SubMsg, SubMsgResponse, SubMsgResult,
 };
 use cw_utils::{parse_execute_response_data, parse_instantiate_response_data};
-use derivative::Derivative;
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Debug;
@@ -18,8 +17,7 @@ use std::fmt::Debug;
 // An Execute message reply otherwise.
 pub const EXECUTE_REPLY_BASE_ID: u64 = i64::MAX as u64;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
-#[derivative(Default(bound = "", new = "true"))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Message<ExecC>
 where
     ExecC: Debug + PartialEq + Clone + JsonSchema + 'static,
@@ -31,8 +29,7 @@ where
 }
 
 // This can take some data... but happy to accept {}
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
-#[derivative(Default(bound = "", new = "true"))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct InitMessage<ExecC>
 where
     ExecC: Debug + PartialEq + Clone + JsonSchema + 'static,

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -19,11 +19,17 @@ pub mod reflect;
 pub mod stargate;
 
 /// Custom message for testing purposes.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename = "snake_case")]
 pub enum CustomHelperMsg {
-    SetName { name: String },
-    SetAge { age: u32 },
+    SetName {
+        name: String,
+    },
+    SetAge {
+        age: u32,
+    },
+    #[default]
+    NoOp,
 }
 
 impl CustomMsg for CustomHelperMsg {}

--- a/src/tests/test_app.rs
+++ b/src/tests/test_app.rs
@@ -1656,7 +1656,7 @@ mod custom_messages {
 
     #[test]
     fn triggering_custom_msg() {
-        let custom_handler = CachingCustomHandler::<CustomHelperMsg, Empty>::new();
+        let custom_handler = CachingCustomHandler::<CustomHelperMsg, Empty>::default();
         let custom_handler_state = custom_handler.state();
 
         let mut app = AppBuilder::new_custom()

--- a/src/tests/test_custom_handler.rs
+++ b/src/tests/test_custom_handler.rs
@@ -14,7 +14,7 @@ fn custom_handler_works() {
     let mut storage = MockStorage::default();
 
     // create custom handler
-    let custom_handler = CachingCustomHandler::<CustomHelperMsg, CustomHelperMsg>::new();
+    let custom_handler = CachingCustomHandler::<CustomHelperMsg, CustomHelperMsg>::default();
 
     // prepare user addresses
     let sender_addr = app.api().addr_make("sender");
@@ -70,7 +70,7 @@ fn custom_handler_has_no_sudo() {
     let mut storage = MockStorage::default();
 
     // create custom handler
-    let custom_handler = CachingCustomHandler::<CustomHelperMsg, CustomHelperMsg>::new();
+    let custom_handler = CachingCustomHandler::<CustomHelperMsg, CustomHelperMsg>::default();
 
     // run sudo function
     assert_eq!(


### PR DESCRIPTION
- Removed [derivative](https://crates.io/crates/derivative) crate from MultiTest dependencies.
- Upgraded other dependencies.