### PR TITLE
Use `cw_serde` where appropriate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "bech32",
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ cosmwasm_2_1 = ["cosmwasm_2_0", "cosmwasm-std/cosmwasm_2_1"]
 [dependencies]
 anyhow = "1.0.89"
 bech32 = "0.11.0"
+cosmwasm-schema = "2.1.3"
 cosmwasm-std = "2.1.4"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"

--- a/src/test_helpers/hackatom.rs
+++ b/src/test_helpers/hackatom.rs
@@ -1,27 +1,25 @@
 //! Simplified contract which when executed releases the funds to beneficiary
 
 use crate::{Contract, ContractWrapper};
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, BankMsg, Binary, CustomMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response,
     StdError,
 };
 use cw_storage_plus::Item;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cw_serde]
 pub struct InstantiateMsg {
     pub beneficiary: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cw_serde]
 pub struct MigrateMsg {
     // just use some other string, so we see there are other types
     pub new_guy: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum QueryMsg {
     // returns InstantiateMsg
     Beneficiary {},

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,9 +1,8 @@
 #![cfg(test)]
 
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::CustomMsg;
 use cw_storage_plus::Item;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 pub mod caller;
 pub mod echo;
@@ -19,7 +18,8 @@ pub mod reflect;
 pub mod stargate;
 
 /// Custom message for testing purposes.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cw_serde]
+#[derive(Default)]
 #[serde(rename = "snake_case")]
 pub enum CustomHelperMsg {
     SetName {

--- a/src/test_helpers/payout.rs
+++ b/src/test_helpers/payout.rs
@@ -1,30 +1,29 @@
 use crate::test_helpers::COUNT;
 use crate::{Contract, ContractWrapper};
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, BankMsg, Binary, Coin, CustomMsg, Deps, DepsMut, Empty, Env, MessageInfo,
     Response, StdError,
 };
 use cw_storage_plus::Item;
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cw_serde]
 pub struct InstantiateMessage {
     pub payout: Coin,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cw_serde]
 pub struct SudoMsg {
     pub set_count: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cw_serde]
 pub enum QueryMsg {
     Count {},
     Payout {},
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cw_serde]
 pub struct CountResponse {
     pub count: u32,
 }

--- a/src/test_helpers/reflect.rs
+++ b/src/test_helpers/reflect.rs
@@ -1,18 +1,18 @@
 use crate::test_helpers::{payout, CustomHelperMsg, COUNT};
 use crate::{Contract, ContractWrapper};
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, Binary, Deps, DepsMut, Empty, Env, Event, MessageInfo, Reply, Response,
     StdError, SubMsg,
 };
 use cw_storage_plus::Map;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cw_serde]
 pub struct Message {
     pub messages: Vec<SubMsg<CustomHelperMsg>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cw_serde]
 pub enum QueryMsg {
     Count {},
     Reply { id: u64 },

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,9 +3,6 @@
 mod test_app;
 mod test_custom_handler;
 mod test_error;
-#[cfg(feature = "stargate")]
 mod test_gov;
-#[cfg(feature = "stargate")]
 mod test_ibc;
-#[cfg(feature = "stargate")]
 mod test_stargate;

--- a/src/tests/test_gov.rs
+++ b/src/tests/test_gov.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::test_helpers::gov;
 use crate::{no_init, App, AppBuilder, Executor, GovAcceptingModule};
 use cosmwasm_std::Empty;

--- a/src/tests/test_ibc.rs
+++ b/src/tests/test_ibc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::test_helpers::ibc;
 use crate::{no_init, App, AppBuilder, Executor, IbcAcceptingModule};
 use cosmwasm_std::Empty;

--- a/src/tests/test_stargate.rs
+++ b/src/tests/test_stargate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::test_helpers::stargate;
 use crate::{no_init, App, AppBuilder, Executor, StargateAccepting};
 use cosmwasm_std::Empty;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,23 +15,22 @@ mod test_wasm;
 mod test_contracts {
 
     pub mod counter {
+        use cosmwasm_schema::cw_serde;
         use cosmwasm_std::{
             to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError,
             WasmMsg,
         };
         use cw_multi_test::{Contract, ContractWrapper};
         use cw_storage_plus::Item;
-        use serde::{Deserialize, Serialize};
 
         const COUNTER: Item<u64> = Item::new("counter");
 
-        #[derive(Debug, Clone, Serialize, Deserialize)]
-        #[serde(rename_all = "snake_case")]
+        #[cw_serde]
         pub enum CounterQueryMsg {
             Counter {},
         }
 
-        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cw_serde]
         pub struct CounterResponseMsg {
             pub value: u64,
         }

--- a/tests/test_bank/test_init_balance.rs
+++ b/tests/test_bank/test_init_balance.rs
@@ -1,7 +1,6 @@
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, CustomMsg, CustomQuery, Uint128};
 use cw_multi_test::{custom_app, App, AppBuilder, BasicApp};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 const USER: &str = "user";
 const DENOM: &str = "denom";
@@ -52,15 +51,13 @@ fn initializing_balance_without_builder_should_work() {
 
 #[test]
 fn initializing_balance_custom_app_should_work() {
-    #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-    #[serde(rename = "snake_case")]
+    #[cw_serde]
     pub enum CustomHelperMsg {
         HelperMsg,
     }
     impl CustomMsg for CustomHelperMsg {}
 
-    #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-    #[serde(rename = "snake_case")]
+    #[cw_serde]
     pub enum CustomHelperQuery {
         HelperQuery,
     }


### PR DESCRIPTION
Instead of long `derive` annotations used `cw_serde` where appropriate/possible.