### PR TITLE
Fix `SubMsg` payload not forwarded.

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -811,7 +811,11 @@ where
         msg: SubMsg<ExecC>,
     ) -> AnyResult<AppResponse> {
         let SubMsg {
-            msg, id, reply_on, ..
+            msg,
+            id,
+            reply_on,
+            payload,
+            ..
         } = msg;
 
         // execute in cache
@@ -824,7 +828,7 @@ where
             if matches!(reply_on, ReplyOn::Always | ReplyOn::Success) {
                 let reply = Reply {
                     id,
-                    payload: Default::default(),
+                    payload,
                     gas_used: 0,
                     result: SubMsgResult::Ok(
                         #[allow(deprecated)]
@@ -850,7 +854,7 @@ where
             if matches!(reply_on, ReplyOn::Always | ReplyOn::Error) {
                 let reply = Reply {
                     id,
-                    payload: Default::default(),
+                    payload,
                     gas_used: 0,
                     result: SubMsgResult::Err(format!("{:?}", e)),
                 };


### PR DESCRIPTION
Payload is not forwarded while parsing `SubMsg`.

This PR is missing test coverage.