### PR TITLE
Replaced `todo!` with `unimplemented!`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -297,21 +297,20 @@ where
     /// // contract implementation
     /// mod echo {
     ///   // contract entry points not shown here
-    /// #  use std::todo;
     /// #  use cosmwasm_std::{Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError, SubMsg, WasmMsg};
     /// #  use serde::{Deserialize, Serialize};
     /// #  use cw_multi_test::{Contract, ContractWrapper};
     /// #
     /// #  fn instantiate(_: DepsMut, _: Env, _: MessageInfo, _: Empty) -> Result<Response, StdError> {
-    /// #    todo!()
+    /// #    unimplemented!()
     /// #  }
     /// #
     /// #  fn execute(_: DepsMut, _: Env, _info: MessageInfo, msg: WasmMsg) -> Result<Response, StdError> {
-    /// #    todo!()
+    /// #    unimplemented!()
     /// #  }
     /// #
     /// #  fn query(_deps: Deps, _env: Env, _msg: Empty) -> Result<Binary, StdError> {
-    /// #    todo!()
+    /// #    unimplemented!()
     /// #  }
     /// #
     ///   pub fn contract() -> Box<dyn Contract<Empty>> {


### PR DESCRIPTION
According to this description from the official Rust documentation:
https://doc.rust-lang.org/std/macro.todo.html
replaced `todo!()` macros with `unimplemented!()` in documentation tests.