### PR TITLE
Refactoring of storage in test helpers

### DIFF
--- a/src/test_helpers/gov.rs
+++ b/src/test_helpers/gov.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::{Contract, ContractWrapper};
 use cosmwasm_std::{
     Binary, CosmosMsg, Deps, DepsMut, Empty, Env, GovMsg, MessageInfo, Response, StdResult,

--- a/src/test_helpers/ibc.rs
+++ b/src/test_helpers/ibc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::{Contract, ContractWrapper};
 use cosmwasm_std::{
     Binary, CosmosMsg, Deps, DepsMut, Empty, Env, IbcMsg, MessageInfo, Response, StdResult,

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -2,19 +2,15 @@
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::CustomMsg;
-use cw_storage_plus::Item;
 
 pub mod caller;
 pub mod echo;
 pub mod error;
-#[cfg(feature = "stargate")]
 pub mod gov;
 pub mod hackatom;
-#[cfg(feature = "stargate")]
 pub mod ibc;
 pub mod payout;
 pub mod reflect;
-#[cfg(feature = "stargate")]
 pub mod stargate;
 
 /// Custom message for testing purposes.
@@ -33,6 +29,3 @@ pub enum CustomHelperMsg {
 }
 
 impl CustomMsg for CustomHelperMsg {}
-
-/// Persisted counter for testing purposes.
-pub const COUNT: Item<u32> = Item::new("count");

--- a/src/test_helpers/payout.rs
+++ b/src/test_helpers/payout.rs
@@ -1,4 +1,3 @@
-use crate::test_helpers::COUNT;
 use crate::{Contract, ContractWrapper};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
@@ -28,6 +27,7 @@ pub struct CountResponse {
     pub count: u32,
 }
 
+const COUNT: Item<u32> = Item::new("count");
 const PAYOUT: Item<InstantiateMessage> = Item::new("payout");
 
 fn instantiate(

--- a/src/test_helpers/reflect.rs
+++ b/src/test_helpers/reflect.rs
@@ -1,11 +1,11 @@
-use crate::test_helpers::{payout, CustomHelperMsg, COUNT};
+use crate::test_helpers::{payout, CustomHelperMsg};
 use crate::{Contract, ContractWrapper};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, Binary, Deps, DepsMut, Empty, Env, Event, MessageInfo, Reply, Response,
     StdError, SubMsg,
 };
-use cw_storage_plus::Map;
+use cw_storage_plus::{Item, Map};
 
 #[cw_serde]
 pub struct Message {
@@ -18,6 +18,7 @@ pub enum QueryMsg {
     Reply { id: u64 },
 }
 
+const COUNT: Item<u32> = Item::new("count");
 const REFLECT: Map<u64, Reply> = Map::new("reflect");
 
 fn instantiate(

--- a/src/test_helpers/stargate.rs
+++ b/src/test_helpers/stargate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stargate")]
+
 use crate::{Contract, ContractWrapper};
 use cosmwasm_std::{
     Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,


### PR DESCRIPTION
- Removed the global counter storage item from test helpers.
- Used this counter locally in each test contract.
- This way prepared these contract to incremental porting to use `storey`.
- Moved feature gates to whole files when appropriate.