### PR TITLE
Refactored reflect test helper

### DIFF
--- a/src/test_helpers/reflect.rs
+++ b/src/test_helpers/reflect.rs
@@ -1,62 +1,80 @@
-use crate::test_helpers::{payout, CustomHelperMsg};
+//! # Reflecting contract
+
 use crate::{Contract, ContractWrapper};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_json_binary, Binary, Deps, DepsMut, Empty, Env, Event, MessageInfo, Reply, Response,
-    StdError, SubMsg,
+    to_json_binary, Binary, CustomMsg, Deps, DepsMut, Empty, Env, Event, MessageInfo, Reply,
+    Response, StdError, StdResult, SubMsg,
 };
 use cw_storage_plus::{Item, Map};
+use serde::de::DeserializeOwned;
 
 #[cw_serde]
-pub struct Message {
-    pub messages: Vec<SubMsg<CustomHelperMsg>>,
+#[derive(Default)]
+pub struct ExecMessage<C>
+where
+    C: CustomMsg + 'static,
+{
+    pub sub_msg: Vec<SubMsg<C>>,
 }
 
 #[cw_serde]
-pub enum QueryMsg {
-    Count {},
+pub enum QueryMessage {
+    Count,
     Reply { id: u64 },
 }
 
-const COUNT: Item<u32> = Item::new("count");
+#[cw_serde]
+pub struct ReflectResponse {
+    pub count: u32,
+}
+
+const COUNTER: Item<u32> = Item::new("counter");
 const REFLECT: Map<u64, Reply> = Map::new("reflect");
 
-fn instantiate(
+fn instantiate<C>(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
     _msg: Empty,
-) -> Result<Response<CustomHelperMsg>, StdError> {
-    COUNT.save(deps.storage, &0)?;
+) -> StdResult<Response<C>>
+where
+    C: CustomMsg + 'static,
+{
+    COUNTER.save(deps.storage, &0)?;
     Ok(Response::default())
 }
 
-fn execute(
+fn execute<C>(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    msg: Message,
-) -> Result<Response<CustomHelperMsg>, StdError> {
-    COUNT.update::<_, StdError>(deps.storage, |old| Ok(old + 1))?;
-
-    Ok(Response::new().add_submessages(msg.messages))
+    msg: ExecMessage<C>,
+) -> StdResult<Response<C>>
+where
+    C: CustomMsg + 'static,
+{
+    COUNTER.update::<_, StdError>(deps.storage, |value| Ok(value + 1))?;
+    Ok(Response::new().add_submessages(msg.sub_msg))
 }
 
-fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
+fn query(deps: Deps, _env: Env, msg: QueryMessage) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Count {} => {
-            let count = COUNT.load(deps.storage)?;
-            let res = payout::CountResponse { count };
-            to_json_binary(&res)
+        QueryMessage::Count => {
+            let count = COUNTER.load(deps.storage)?;
+            to_json_binary(&ReflectResponse { count })
         }
-        QueryMsg::Reply { id } => {
+        QueryMessage::Reply { id } => {
             let reply = REFLECT.load(deps.storage, id)?;
             to_json_binary(&reply)
         }
     }
 }
 
-fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response<CustomHelperMsg>, StdError> {
+fn reply<C>(deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response<C>>
+where
+    C: CustomMsg + 'static,
+{
     REFLECT.save(deps.storage, msg.id, &msg)?;
     // add custom event here to test
     let event = Event::new("custom")
@@ -65,7 +83,9 @@ fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response<CustomHelperMs
     Ok(Response::new().add_event(event))
 }
 
-pub fn contract() -> Box<dyn Contract<CustomHelperMsg>> {
-    let contract = ContractWrapper::new(execute, instantiate, query).with_reply(reply);
-    Box::new(contract)
+pub fn contract<C>() -> Box<dyn Contract<C>>
+where
+    C: CustomMsg + DeserializeOwned + 'static,
+{
+    Box::new(ContractWrapper::new(execute::<C>, instantiate::<C>, query).with_reply(reply::<C>))
 }


### PR DESCRIPTION
Refactored `reflect` test helper to accept any type of the submessage. Will be needed for testing replies from multiple Cosmos messages.