### PR TITLE
feat: add associated types to Stargate trait

### DIFF
--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -128,7 +128,7 @@ impl
             distribution: DistributionKeeper::new(),
             ibc: IbcFailingModule::new(),
             gov: GovFailingModule::new(),
-            stargate: StargateFailing,
+            stargate: StargateFailing::new(),
         }
     }
 }
@@ -164,7 +164,7 @@ where
             distribution: DistributionKeeper::new(),
             ibc: IbcFailingModule::new(),
             gov: GovFailingModule::new(),
-            stargate: StargateFailing,
+            stargate: StargateFailing::new(),
         }
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1387,7 +1387,7 @@ mod test {
             distribution: DistributionKeeper::new(),
             ibc: IbcFailingModule::new(),
             gov: GovFailingModule::new(),
-            stargate: StargateFailing,
+            stargate: StargateFailing::new(),
         }
     }
 


### PR DESCRIPTION
Add associated types to `Stargate` trait to be inlined with the rest of the modules.