### PR TITLE
feat: Add distribution queries

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -694,6 +694,10 @@ where
             QueryRequest::Custom(req) => self.custom.query(api, storage, &querier, block, req),
             #[cfg(feature = "staking")]
             QueryRequest::Staking(req) => self.staking.query(api, storage, &querier, block, req),
+            #[cfg(feature = "staking")]
+            QueryRequest::Distribution(req) => {
+                self.distribution.query(api, storage, &querier, block, req)
+            }
             #[cfg(feature = "stargate")]
             QueryRequest::Ibc(req) => self.ibc.query(api, storage, &querier, block, req),
             #[allow(deprecated)]

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -9,8 +9,8 @@ use cosmwasm_std::{
     Decimal, Decimal256, Delegation, DelegationResponse, DelegationRewardsResponse,
     DelegationTotalRewardsResponse, DelegatorReward, DelegatorValidatorsResponse,
     DelegatorWithdrawAddressResponse, DistributionMsg, DistributionQuery, Empty, Event,
-    FullDelegation, Order, Querier, StakingMsg, StakingQuery, Storage, Timestamp,
-    Uint128, Validator, ValidatorResponse,
+    FullDelegation, Order, Querier, StakingMsg, StakingQuery, Storage, Timestamp, Uint128,
+    Validator, ValidatorResponse,
 };
 use cw_storage_plus::{Deque, Item, Map};
 use schemars::JsonSchema;
@@ -952,7 +952,7 @@ impl DistributionKeeper {
         delegator: &Addr,
     ) -> AnyResult<Vec<String>> {
         let staking_storage = prefixed_read(storage, NAMESPACE_STAKING);
-        
+
         Ok(STAKES
             .prefix(&delegator)
             .keys(&staking_storage, None, None, Order::Ascending)

--- a/tests/test_app_builder/test_with_distribution.rs
+++ b/tests/test_app_builder/test_with_distribution.rs
@@ -1,8 +1,8 @@
 use crate::test_app_builder::MyKeeper;
-use cosmwasm_std::{DistributionMsg, Empty};
+use cosmwasm_std::{DistributionMsg, DistributionQuery, Empty};
 use cw_multi_test::{no_init, AppBuilder, Distribution, Executor};
 
-type MyDistributionKeeper = MyKeeper<DistributionMsg, Empty, Empty>;
+type MyDistributionKeeper = MyKeeper<DistributionMsg, DistributionQuery, Empty>;
 
 impl Distribution for MyDistributionKeeper {}
 


### PR DESCRIPTION
Add distribution queries.
Implemented:

1. `DistributionQuery::DelegatorValidators`
2. `DistributionQuery::DelegatorWithdrawAddress`
3. `DistributionQuery::DelegationTotalRewards`
4. `DistributionQuery::DelegationRewards`

Fix #249