### PR TITLE
`MigrateInfo` backport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
 jobs:
   build_and_test:
     docker:
-      - image: rust:1.78
+      - image: rust:1.82
     working_directory: ~/project
     steps:
       - checkout
@@ -42,8 +42,8 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.78-{{ checksum "Cargo.lock" }}
-            - cargocache-v2-multi-test:1.78-
+            - cargocache-v2-multi-test:1.82-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-multi-test:1.82-
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -54,7 +54,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.78-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.82-{{ checksum "Cargo.lock" }}
 
   build_minimal:
     docker:
@@ -74,7 +74,7 @@ jobs:
           command: cargo update -p ahash && cargo update -p num-bigint
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.78-minimal-{{ checksum "Cargo.toml" }}
+            - cargocache-v2-multi-test:1.82-minimal-{{ checksum "Cargo.toml" }}
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features
@@ -85,11 +85,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.78-minimal-{{ checksum "Cargo.toml" }}
+          key: cargocache-v2-multi-test:1.82-minimal-{{ checksum "Cargo.toml" }}
 
   build_maximal:
     docker:
-      - image: rust:1.78
+      - image: rust:1.82
     working_directory: ~/project
     steps:
       - checkout
@@ -101,7 +101,7 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.78-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-multi-test:1.82-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked --all-features
@@ -112,11 +112,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.78-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.82-{{ checksum "Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.78
+      - image: rust:1.82
     steps:
       - checkout
       - run:
@@ -127,8 +127,8 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.78-{{ checksum "Cargo.lock" }}
-            - cargocache-v2-lint-rust:1.78-
+            - cargocache-v2-lint-rust:1.82-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.82-
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -147,7 +147,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.78-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.82-{{ checksum "Cargo.lock" }}
 
   coverage:
     # https://circleci.com/developer/images?imageType=machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v2.5.0](https://github.com/CosmWasm/cw-multi-test/tree/v2.5.0) (2025-07-16)
+
+[Full Changelog](https://github.com/CosmWasm/cw-multi-test/compare/v2.4.0...v2.5.0)
+
+**Closed issues:**
+
+- Missing `MigrateInfo` [\#258](https://github.com/CosmWasm/cw-multi-test/issues/258) (reported by [gluax](https://github.com/gluax))
+
+**Merged pull requests:**
+
+- `MigrateInfo` backport [\#266](https://github.com/CosmWasm/cw-multi-test/pull/266) ([DariuszDepta](https://github.com/DariuszDepta))
+
 ## [v2.4.0](https://github.com/CosmWasm/cw-multi-test/tree/v2.4.0) (2025-04-28)
 
 [Full Changelog](https://github.com/CosmWasm/cw-multi-test/compare/v2.3.3...v2.4.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ cosmwasm-std = "2.2.2"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"
 itertools = "0.14.0"
-prost = "0.13.5"
+prost = "0.14.1"
 schemars = "0.8.22"
 serde = "1.0.219"
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CosmWasm MultiTest
+# MultiTest
 
 [![cw-multi-test on crates.io][crates-badge]][crates-url]
 [![docs][docs-badge]][docs-url]
@@ -14,34 +14,34 @@
 [apache-badge]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [apache-url]: LICENSE
 [notice-url]: NOTICE
+[CosmWasm]: https://github.com/CosmWasm
 
 **Testing tools for multi-contract interactions**
 
 ## Introduction
 
-**CosmWasm MultiTest** is a suite of testing tools designed for facilitating multi-contract
-interactions within the [CosmWasm](https://github.com/CosmWasm) ecosystem.
+**MultiTest** is a suite of testing tools designed for facilitating multi-contract
+interactions within the [CosmWasm] ecosystem.
 Its primary focus is on providing developers with a robust framework for simulating
 complex contract interactions and bank operations.
 
 ## Library capabilities
 
-**CosmWasm MultiTest** enables comprehensive unit testing, including scenarios where contracts
+CosmWasm **MultiTest** enables comprehensive unit testing, including scenarios where contracts
 call other contracts and interact with several modules like bank and staking. Its current implementation
 effectively handles these interactions, providing a realistic testing environment for contract developers.
-The team is committed to extending **CosmWasm MultiTest**'s capabilities, making it a versatile tool
+The team is committed to extending CosmWasm **MultiTest**'s capabilities, making it a versatile tool
 for various blockchain interaction tests.
 
 ## Feature flags
 
-**CosmWasm MultiTest** library provides several feature flags that can be enabled like shown below:
+CosmWasm **MultiTest** library provides several feature flags that can be enabled like shown below:
 
 ```toml
 [dev-dependencies]
 cw-multi-test = { version = "2", features = ["staking", "stargate", "cosmwasm_2_2"] }
 ```
 
-Since version 2.1.0, **CosmWasm MultiTest** has no default features enabled.
 The table below summarizes all available features:
 
 | Feature          | Description                                                                                        |
@@ -59,10 +59,9 @@ The table below summarizes all available features:
 
 ## Conclusion
 
-**CosmWasm MultiTest** stands as a vital development tool in
-the [CosmWasm](https://github.com/CosmWasm) ecosystem, especially for developers engaged
-in building complex decentralized applications. As the framework evolves, it is poised to become
-an even more integral part of the [CosmWasm](https://github.com/CosmWasm) development toolkit.
+CosmWasm **MultiTest** stands as a vital development tool in the [CosmWasm] ecosystem,
+especially for developers engaged in building complex decentralized applications.
+As the framework evolves, it is poised to become an even more integral part of the [CosmWasm] development toolkit.
 Users are encouraged to stay updated with its progress and contribute to its development.
 
 ## License

--- a/src/api.rs
+++ b/src/api.rs
@@ -158,7 +158,7 @@ impl<T: bech32::Checksum> MockApiBech<T> {
     pub fn addr_make(&self, input: &str) -> Addr {
         match Hrp::parse(self.prefix) {
             Ok(hrp) => Addr::unchecked(encode::<T>(hrp, Sha256::digest(input).as_slice()).unwrap()),
-            Err(reason) => panic!("Generating address failed with reason: {}", reason),
+            Err(reason) => panic!("Generating address failed with reason: {reason}"),
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -818,7 +818,7 @@ where
             Ok(v) => v,
             Err(e) => {
                 return SystemResult::Err(SystemError::InvalidRequest {
-                    error: format!("Parsing query request: {}", e),
+                    error: format!("Parsing query request: {e}"),
                     request: bin_request.into(),
                 })
             }

--- a/src/checksums.rs
+++ b/src/checksums.rs
@@ -19,6 +19,6 @@ impl ChecksumGenerator for SimpleChecksumGenerator {
     /// Calculates the checksum based on code identifier. The resulting
     /// checksum is 32-byte length SHA2 digest.
     fn checksum(&self, _creator: &Addr, code_id: u64) -> Checksum {
-        Checksum::generate(format!("contract code {}", code_id).as_bytes())
+        Checksum::generate(format!("contract code {code_id}").as_bytes())
     }
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -459,7 +459,7 @@ where
             CosmosMsg::Ibc(ibc) => CosmosMsg::Ibc(ibc),
             #[cfg(feature = "cosmwasm_2_0")]
             CosmosMsg::Any(any) => CosmosMsg::Any(any),
-            other => panic!("unknown message variant {:?}", other),
+            other => panic!("unknown message variant {other:?}"),
         },
         gas_limit: msg.gas_limit,
         reply_on: msg.reply_on,

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -1,6 +1,8 @@
 //! # Implementation of the contract trait and contract wrapper
 
 use crate::error::{anyhow, bail, AnyError, AnyResult};
+#[cfg(feature = "cosmwasm_2_2")]
+use cosmwasm_std::MigrateInfo;
 use cosmwasm_std::{
     from_json, Binary, Checksum, CosmosMsg, CustomMsg, CustomQuery, Deps, DepsMut, Empty, Env,
     MessageInfo, QuerierWrapper, Reply, Response, SubMsg,
@@ -32,7 +34,12 @@ where
     fn sudo(&self, deps: DepsMut<Q>, env: Env, msg: Vec<u8>) -> AnyResult<Response<C>>;
 
     /// Evaluates contract's `migrate` entry-point.
+    #[cfg(not(feature = "cosmwasm_2_2"))]
     fn migrate(&self, deps: DepsMut<Q>, env: Env, msg: Vec<u8>) -> AnyResult<Response<C>>;
+
+    /// Evaluates contract's `migrate` entry-point.
+    #[cfg(feature = "cosmwasm_2_2")]
+    fn migrate(&self, deps: DepsMut<Q>, env: Env, msg: Vec<u8>, info: MigrateInfo) -> AnyResult<Response<C>>;
 
     /// Returns the provided checksum of the contract's Wasm blob.
     fn checksum(&self) -> Option<Checksum> {
@@ -50,7 +57,10 @@ mod closures {
     pub type QueryFn<T, E, Q> = fn(deps: Deps<Q>, env: Env, msg: T) -> Result<Binary, E>;
     pub type ReplyFn<C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: Reply) -> Result<Response<C>, E>;
     pub type SudoFn<T, C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T) -> Result<Response<C>, E>;
+    #[cfg(not(feature = "cosmwasm_2_2"))]
     pub type MigrateFn<T, C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T) -> Result<Response<C>, E>;
+    #[cfg(feature = "cosmwasm_2_2")]
+    pub type MigrateFn<T, C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T, info: MigrateInfo) -> Result<Response<C>, E>;
 
     // closure types
     pub type InstantiateClosure<T, C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, MessageInfo, T) -> Result<Response<C>, E>>;
@@ -58,7 +68,10 @@ mod closures {
     pub type QueryClosure<T, E, Q> = Box<dyn Fn(Deps<Q>, Env, T) -> Result<Binary, E>>;
     pub type ReplyClosure<C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response<C>, E>>;
     pub type SudoClosure<T, C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, T) -> Result<Response<C>, E>>;
+    #[cfg(not(feature = "cosmwasm_2_2"))]
     pub type MigrateClosure<T, C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, T) -> Result<Response<C>, E>>;
+    #[cfg(feature = "cosmwasm_2_2")]
+    pub type MigrateClosure<T, C, E, Q> = Box<dyn Fn(DepsMut<Q>, Env, T, MigrateInfo) -> Result<Response<C>, E>>;
 }
 
 use closures::*;
@@ -453,9 +466,15 @@ where
     Q: CustomQuery + DeserializeOwned,
 {
     Box::new(
+        #[cfg(not(feature = "cosmwasm_2_2"))]
         move |mut deps: DepsMut<Q>, env: Env, msg: T| -> Result<Response<C>, E> {
             let deps = decustomize_deps_mut(&mut deps);
             raw_fn(deps, env, msg).map(customize_response::<C>)
+        },
+        #[cfg(feature = "cosmwasm_2_2")]
+        move |mut deps: DepsMut<Q>, env: Env, msg: T, inf: MigrateInfo| -> Result<Response<C>, E> {
+            let deps = decustomize_deps_mut(&mut deps);
+            raw_fn(deps, env, msg, inf).map(customize_response::<C>)
         },
     )
 }
@@ -600,10 +619,30 @@ where
     /// Returns an error when the contract does not implement [migrate].
     ///
     /// [migrate]: Contract::migrate
+    #[cfg(not(feature = "cosmwasm_2_2"))]
     fn migrate(&self, deps: DepsMut<Q>, env: Env, msg: Vec<u8>) -> AnyResult<Response<C>> {
         let msg: T6 = from_json(msg)?;
         match &self.migrate_fn {
             Some(migrate) => migrate(deps, env, msg).map_err(|err: E6| anyhow!(err)),
+            None => bail!("migrate is not implemented for contract"),
+        }
+    }
+
+    /// Calls [migrate] on wrapped [Contract] trait implementor.
+    /// Returns an error when the contract does not implement [migrate].
+    ///
+    /// [migrate]: Contract::migrate
+    #[cfg(feature = "cosmwasm_2_2")]
+    fn migrate(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: Vec<u8>,
+        info: MigrateInfo,
+    ) -> AnyResult<Response<C>> {
+        let msg: T6 = from_json(msg)?;
+        match &self.migrate_fn {
+            Some(migrate) => migrate(deps, env, msg, info).map_err(|err: E6| anyhow!(err)),
             None => bail!("migrate is not implemented for contract"),
         }
     }

--- a/src/test_helpers/hackatom.rs
+++ b/src/test_helpers/hackatom.rs
@@ -2,6 +2,8 @@
 
 use crate::{Contract, ContractWrapper};
 use cosmwasm_schema::cw_serde;
+#[cfg(feature = "cosmwasm_2_2")]
+use cosmwasm_std::MigrateInfo;
 use cosmwasm_std::{
     to_json_binary, BankMsg, Binary, CustomMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response,
     StdError,
@@ -59,7 +61,23 @@ fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
     }
 }
 
+#[cfg(not(feature = "cosmwasm_2_2"))]
 fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, StdError> {
+    HACKATOM.update::<_, StdError>(deps.storage, |mut state| {
+        state.beneficiary = msg.new_guy;
+        Ok(state)
+    })?;
+    let resp = Response::new().add_attribute("migrate", "successful");
+    Ok(resp)
+}
+
+#[cfg(feature = "cosmwasm_2_2")]
+fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    msg: MigrateMsg,
+    _info: MigrateInfo,
+) -> Result<Response, StdError> {
     HACKATOM.update::<_, StdError>(deps.storage, |mut state| {
         state.beneficiary = msg.new_guy;
         Ok(state)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -224,8 +224,7 @@ where
     ) -> AnyResult<AppResponse> {
         self.execute_wasm(api, storage, router, block, sender.clone(), msg.clone())
             .context(format!(
-                "Error executing WasmMsg:\n  sender: {}\n  {:?}",
-                sender, msg
+                "Error executing WasmMsg:\n  sender: {sender}\n  {msg:?}"
             ))
     }
 
@@ -884,7 +883,7 @@ where
                     id,
                     payload,
                     gas_used: 0,
-                    result: SubMsgResult::Err(format!("{:?}", e)),
+                    result: SubMsgResult::Err(format!("{e:?}")),
                 };
                 self.reply(api, router, storage, block, contract, reply)
             } else {
@@ -1738,7 +1737,7 @@ mod test {
                 assert_eq!(to_address.as_str(), user_addr.as_str());
                 assert_eq!(amount.as_slice(), &[payout.clone()]);
             }
-            m => panic!("Unexpected message {:?}", m),
+            m => panic!("Unexpected message {m:?}"),
         }
 
         // and flush before query
@@ -1780,13 +1779,13 @@ mod test {
                 assert_eq!(to_address.as_str(), user_addr.as_str());
                 assert_eq!(amount.as_slice(), &[payout.clone()]);
             }
-            m => panic!("Unexpected message {:?}", m),
+            m => panic!("Unexpected message {m:?}"),
         }
     }
 
     fn assert_no_contract(storage: &dyn Storage, contract_addr: &Addr) {
         let contract = CONTRACTS.may_load(storage, contract_addr).unwrap();
-        assert!(contract.is_none(), "{:?}", contract_addr);
+        assert!(contract.is_none(), "{contract_addr:?}");
     }
 
     #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,6 +6,7 @@ mod test_app_builder;
 mod test_attributes;
 mod test_bank;
 mod test_contract_storage;
+mod test_contract_wrapper;
 mod test_distribution;
 mod test_empty_contract;
 mod test_module;

--- a/tests/test_app_builder/test_with_bank.rs
+++ b/tests/test_app_builder/test_with_bank.rs
@@ -56,7 +56,7 @@ fn building_app_with_custom_bank_should_work() {
 
     // executing bank query should return an error defined in custom keeper
     assert_eq!(
-        format!("Generic error: Querier contract error: {}", QUERY_MSG),
+        format!("Generic error: Querier contract error: {QUERY_MSG}"),
         app.wrap()
             .query_balance(recipient_addr, denom)
             .unwrap_err()

--- a/tests/test_app_builder/test_with_ibc.rs
+++ b/tests/test_app_builder/test_with_ibc.rs
@@ -36,7 +36,7 @@ fn building_app_with_custom_ibc_should_work() {
 
     // executing ibc query should return an error defined in custom keeper
     assert_eq!(
-        format!("Generic error: Querier contract error: {}", QUERY_MSG),
+        format!("Generic error: Querier contract error: {QUERY_MSG}"),
         app.wrap()
             .query::<IbcQuery>(&QueryRequest::Ibc(
                 #[allow(deprecated)]

--- a/tests/test_app_builder/test_with_staking.rs
+++ b/tests/test_app_builder/test_with_staking.rs
@@ -55,7 +55,7 @@ fn building_app_with_custom_staking_should_work() {
 
     // executing staking query should return an error defined in custom keeper
     assert_eq!(
-        format!("Generic error: Querier contract error: {}", QUERY_MSG),
+        format!("Generic error: Querier contract error: {QUERY_MSG}"),
         app.wrap().query_all_validators().unwrap_err().to_string()
     );
 }

--- a/tests/test_app_builder/test_with_wasm.rs
+++ b/tests/test_app_builder/test_with_wasm.rs
@@ -151,7 +151,7 @@ fn building_app_with_custom_wasm_should_work() {
 
     // executing wasm query should return an error defined in custom keeper
     assert_eq!(
-        format!("Generic error: Querier contract error: {}", QUERY_MSG),
+        format!("Generic error: Querier contract error: {QUERY_MSG}"),
         app.wrap()
             .query_wasm_code_info(CODE_ID)
             .unwrap_err()

--- a/tests/test_contract_wrapper/mod.rs
+++ b/tests/test_contract_wrapper/mod.rs
@@ -1,0 +1,5 @@
+mod test_custom_wrapper;
+mod test_migrate_entrypoint;
+mod test_migrate_info;
+mod test_required_entrypoints;
+mod test_sudo_entrypoint;

--- a/tests/test_contract_wrapper/test_custom_wrapper.rs
+++ b/tests/test_contract_wrapper/test_custom_wrapper.rs
@@ -1,0 +1,70 @@
+#[cfg(feature = "cosmwasm_2_2")]
+use cosmwasm_std::MigrateInfo;
+use cosmwasm_std::{Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response};
+use cw_multi_test::error::AnyResult;
+use cw_multi_test::Contract;
+
+struct CustomWrapper {}
+
+impl Contract<Empty> for CustomWrapper {
+    fn instantiate(
+        &self,
+        deps: DepsMut<Empty>,
+        env: Env,
+        info: MessageInfo,
+        msg: Vec<u8>,
+    ) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, info, msg);
+        unimplemented!()
+    }
+
+    fn execute(
+        &self,
+        deps: DepsMut<Empty>,
+        env: Env,
+        info: MessageInfo,
+        msg: Vec<u8>,
+    ) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, info, msg);
+        unimplemented!()
+    }
+
+    fn query(&self, deps: Deps<Empty>, env: Env, msg: Vec<u8>) -> AnyResult<Binary> {
+        let _ = (deps, env, msg);
+        unimplemented!()
+    }
+
+    fn reply(&self, deps: DepsMut<Empty>, env: Env, msg: Reply) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, msg);
+        unimplemented!()
+    }
+
+    fn sudo(&self, deps: DepsMut<Empty>, env: Env, msg: Vec<u8>) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, msg);
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "cosmwasm_2_2"))]
+    fn migrate(&self, deps: DepsMut<Empty>, env: Env, msg: Vec<u8>) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, msg);
+        unimplemented!()
+    }
+
+    #[cfg(feature = "cosmwasm_2_2")]
+    fn migrate(
+        &self,
+        deps: DepsMut<Empty>,
+        env: Env,
+        msg: Vec<u8>,
+        info: MigrateInfo,
+    ) -> AnyResult<Response<Empty>> {
+        let _ = (deps, env, msg, info);
+        unimplemented!()
+    }
+}
+
+#[test]
+fn creating_custom_wrapper_should_work() {
+    let wrapper = CustomWrapper {};
+    assert_eq!(None, wrapper.checksum());
+}

--- a/tests/test_contract_wrapper/test_migrate_entrypoint.rs
+++ b/tests/test_contract_wrapper/test_migrate_entrypoint.rs
@@ -1,0 +1,166 @@
+#![cfg(not(feature = "cosmwasm_2_2"))]
+
+#[test]
+fn migrate_entrypoint_should_work() {
+    use cosmwasm_std::{from_json, Empty};
+    use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
+    use cw_utils::parse_execute_response_data;
+
+    // Contract definition.
+    mod the_contract {
+        use cosmwasm_schema::cw_serde;
+        use cosmwasm_std::{
+            to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+        };
+
+        #[cw_serde]
+        pub struct MigrateMsg {
+            pub some_string: String,
+        }
+
+        pub fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+            to_json_binary(&Empty {})
+        }
+
+        pub fn migrate(_deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
+            Ok(Response::default().set_data(to_json_binary(&msg)?))
+        }
+    }
+
+    use the_contract::*;
+
+    // Returns the wrapped contract.
+    pub fn contract() -> Box<dyn Contract<Empty>> {
+        Box::new(ContractWrapper::new(execute, instantiate, query).with_migrate(migrate))
+    }
+
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the contract code on chain.
+    let code_id = app.store_code(contract());
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Instantiate the contract.
+    let contract_addr = app
+        .instantiate_contract(
+            code_id,
+            owner_addr.clone(),
+            &Empty {},
+            &[],
+            "the-contract",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Calling `migrate` entrypoint should work.
+    let msg = MigrateMsg {
+        some_string: "some string".to_string(),
+    };
+    let app_response = app
+        .migrate_contract(admin_addr, contract_addr, &msg, 1)
+        .unwrap();
+    let migrate_response = parse_execute_response_data(&app_response.data.unwrap()).unwrap();
+    let response_msg: MigrateMsg = from_json(migrate_response.data.unwrap()).unwrap();
+    assert_eq!("some string", response_msg.some_string);
+}
+
+#[test]
+fn migrate_empty_entrypoint_should_work() {
+    use cosmwasm_std::Empty;
+    use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
+
+    // Contract definition.
+    mod the_contract {
+        use cosmwasm_std::{
+            to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+        };
+
+        pub fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+            to_json_binary(&Empty {})
+        }
+
+        pub fn migrate(_deps: DepsMut, _env: Env, _msg: Empty) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+    }
+
+    // Returns the wrapped contract.
+    pub fn contract() -> Box<dyn Contract<Empty>> {
+        Box::new(
+            ContractWrapper::new(
+                the_contract::execute,
+                the_contract::instantiate,
+                the_contract::query,
+            )
+            .with_migrate_empty(the_contract::migrate),
+        )
+    }
+
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the contract code on chain.
+    let code_id = app.store_code(contract());
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Instantiate the contract.
+    let contract_addr = app
+        .instantiate_contract(
+            code_id,
+            owner_addr.clone(),
+            &Empty {},
+            &[],
+            "the-contract",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Calling `migrate` entrypoint should work.
+    let res = app
+        .migrate_contract(admin_addr, contract_addr, &Empty {}, 1)
+        .unwrap();
+    assert_eq!(None, res.data);
+}

--- a/tests/test_contract_wrapper/test_migrate_info.rs
+++ b/tests/test_contract_wrapper/test_migrate_info.rs
@@ -1,0 +1,217 @@
+#![cfg(feature = "cosmwasm_2_2")]
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, MigrateInfo, Response,
+    StdResult,
+};
+use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
+use cw_storage_plus::Item;
+
+// The initial version of the contract.
+mod contract_version_one {
+    use super::*;
+
+    const VERSION: Item<u32> = Item::new("version");
+
+    #[cw_serde]
+    pub struct InstantiateMsg {
+        pub value: u32,
+    }
+
+    #[cw_serde]
+    pub struct ContractResponseMsg {
+        pub value: u32,
+    }
+
+    pub fn instantiate(
+        deps: DepsMut,
+        _env: Env,
+        _info: MessageInfo,
+        msg: InstantiateMsg,
+    ) -> StdResult<Response> {
+        VERSION.save(deps.storage, &msg.value)?;
+        Ok(Response::default())
+    }
+
+    pub fn execute(
+        _deps: DepsMut,
+        _env: Env,
+        _info: MessageInfo,
+        _msg: Empty,
+    ) -> StdResult<Response> {
+        Ok(Response::default())
+    }
+
+    pub fn query(deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+        to_json_binary(&ContractResponseMsg {
+            value: VERSION.may_load(deps.storage)?.unwrap(),
+        })
+    }
+}
+
+// Contract definition after changes that require migration.
+mod contract_version_two {
+    use super::*;
+
+    const NEGATED_VERSION: Item<i64> = Item::new("negated-version");
+    const MIGRATION_VERSION: Item<u64> = Item::new("migration-version");
+
+    #[cw_serde]
+    pub struct ContractResponseMsg {
+        pub negated_version: i64,
+        pub migration_version: u64,
+    }
+
+    pub fn instantiate(
+        _deps: DepsMut,
+        _env: Env,
+        _info: MessageInfo,
+        _msg: Empty,
+    ) -> StdResult<Response> {
+        Ok(Response::default())
+    }
+
+    pub fn execute(
+        _deps: DepsMut,
+        _env: Env,
+        _info: MessageInfo,
+        _msg: Empty,
+    ) -> StdResult<Response> {
+        Ok(Response::default())
+    }
+
+    pub fn query(deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+        to_json_binary(&ContractResponseMsg {
+            negated_version: NEGATED_VERSION.may_load(deps.storage)?.unwrap(),
+            migration_version: MIGRATION_VERSION.may_load(deps.storage)?.unwrap(),
+        })
+    }
+
+    pub fn migrate(
+        deps: DepsMut,
+        _env: Env,
+        _msg: Empty,
+        info: MigrateInfo,
+    ) -> StdResult<Response> {
+        const VERSION: Item<u32> = Item::new("version");
+        let version = VERSION.may_load(deps.storage)?.unwrap();
+        NEGATED_VERSION.save(deps.storage, &-(version as i64))?;
+        MIGRATION_VERSION.save(deps.storage, &info.old_migrate_version.unwrap_or(0))?;
+        Ok(Response::default())
+    }
+}
+
+// Returns the wrapped contract before improvements.
+pub fn contract_one() -> Box<dyn Contract<Empty>> {
+    Box::new(ContractWrapper::new(
+        contract_version_one::execute,
+        contract_version_one::instantiate,
+        contract_version_one::query,
+    ))
+}
+
+// Returns the wrapped contract after improvements.
+pub fn contract_two() -> Box<dyn Contract<Empty>> {
+    Box::new(
+        ContractWrapper::new(
+            contract_version_two::execute,
+            contract_version_two::instantiate,
+            contract_version_two::query,
+        )
+        .with_migrate(contract_version_two::migrate),
+    )
+}
+
+#[test]
+fn migrate_info_should_work() {
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the code of the contract one on chain.
+    let code_id_one = app.store_code(contract_one());
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Instantiate the contract in version one.
+    let contract_addr_one = app
+        .instantiate_contract(
+            code_id_one,
+            owner_addr.clone(),
+            &contract_version_one::InstantiateMsg { value: 100 },
+            &[],
+            "contract-one",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Query the state of the contract in version one.
+    let response_one: contract_version_one::ContractResponseMsg = app
+        .wrap()
+        .query_wasm_smart(contract_addr_one.clone(), &Empty {})
+        .unwrap();
+    assert_eq!(100, response_one.value);
+
+    // Store the code of the contract two on chain.
+    let code_id_two = app.store_code(contract_two());
+
+    // Execute the migration entrypoint.
+    // Migrating from contract version one to two and from code id = 1 to code id = 2.
+    app.migrate_contract(
+        admin_addr.clone(),
+        contract_addr_one.clone(),
+        &Empty {},
+        code_id_two,
+    )
+    .unwrap();
+
+    // Query the state of the contract in version two.
+    let response_two: contract_version_two::ContractResponseMsg = app
+        .wrap()
+        .query_wasm_smart(contract_addr_one.clone(), &Empty {})
+        .unwrap();
+    assert_eq!(-100, response_two.negated_version);
+    assert_eq!(1, response_two.migration_version);
+
+    // Store the code of the contract one on chain again.
+    let code_id_three = app.store_code(contract_one());
+
+    // Instantiate another contract in version one.
+    let contract_addr_two = app
+        .instantiate_contract(
+            code_id_three,
+            owner_addr.clone(),
+            &contract_version_one::InstantiateMsg { value: 200 },
+            &[],
+            "contract-two",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Query the state of the second contract in version one.
+    let response_one: contract_version_one::ContractResponseMsg = app
+        .wrap()
+        .query_wasm_smart(contract_addr_two.clone(), &Empty {})
+        .unwrap();
+    assert_eq!(200, response_one.value);
+
+    // Execute the migration entrypoint.
+    // Migrating from contract version one to two and from code id = 3 to code id = 2.
+    app.migrate_contract(
+        admin_addr.clone(),
+        contract_addr_two.clone(),
+        &Empty {},
+        code_id_two,
+    )
+    .unwrap();
+
+    // Query the state of the contract two in version two.
+    let response_two: contract_version_two::ContractResponseMsg = app
+        .wrap()
+        .query_wasm_smart(contract_addr_two.clone(), &Empty {})
+        .unwrap();
+    assert_eq!(-200, response_two.negated_version);
+    assert_eq!(3, response_two.migration_version);
+}

--- a/tests/test_contract_wrapper/test_required_entrypoints.rs
+++ b/tests/test_contract_wrapper/test_required_entrypoints.rs
@@ -1,0 +1,130 @@
+#[test]
+#[cfg(feature = "cosmwasm_1_2")]
+fn required_entrypoints_should_work() {
+    use cosmwasm_std::{Checksum, Empty};
+    use cw_multi_test::{App, AppResponse, Contract, ContractWrapper, Executor, IntoAddr};
+
+    // Contract definition. Contains only required entrypoints.
+    mod the_contract {
+        use cosmwasm_std::{
+            to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+        };
+
+        pub fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+            to_json_binary(&Empty {})
+        }
+    }
+
+    // Returns the wrapped contract with simulated checksum.
+    pub fn contract() -> Box<dyn Contract<Empty>> {
+        Box::new(
+            ContractWrapper::new(
+                the_contract::execute,
+                the_contract::instantiate,
+                the_contract::query,
+            )
+            .with_checksum(Checksum::generate(&[1, 2, 3, 4, 5, 6, 7, 8, 9])),
+        )
+    }
+
+    // Create the contract wrapper.
+    let contract = contract();
+
+    // Save checksum for later use.
+    let checksum = contract.checksum();
+
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the contract code on chain.
+    let code_id = app.store_code(contract);
+
+    assert_eq!(1, code_id);
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Calling `instantiate` entrypoint should work.
+    let contract_addr = app
+        .instantiate_contract(
+            code_id,
+            owner_addr.clone(),
+            &Empty {},
+            &[],
+            "the-contract",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Calling `execute` entrypoint should work.
+    let _: AppResponse = app
+        .execute_contract(owner_addr.clone(), contract_addr.clone(), &Empty {}, &[])
+        .unwrap();
+
+    // Calling `query` entrypoint should work.
+    let _: Empty = app
+        .wrap()
+        .query_wasm_smart(contract_addr.clone(), &Empty {})
+        .unwrap();
+
+    // Querying checksum should work.
+    let code_info_response = app.wrap().query_wasm_code_info(code_id).unwrap();
+    assert_eq!(
+        checksum.unwrap().as_slice(),
+        code_info_response.checksum.as_slice()
+    );
+
+    // Calling `sudo` entrypoint should fail, because is not implemented in the contract.
+    let res = app.wasm_sudo(contract_addr.clone(), &Empty {});
+
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("sudo is not implemented for contract"));
+
+    // Calling `migrate` entrypoint should now fail because we point the non-existing new code id.
+    let res = app.migrate_contract(owner_addr.clone(), contract_addr.clone(), &Empty {}, 2);
+
+    assert!(res
+        .unwrap_err()
+        .root_cause()
+        .to_string()
+        .starts_with("Cannot migrate contract to unregistered code id"));
+
+    // Calling `migrate` entrypoint should now fail because the owner is not an admin.
+    let res = app.migrate_contract(owner_addr, contract_addr.clone(), &Empty {}, 1);
+
+    assert!(res
+        .unwrap_err()
+        .root_cause()
+        .to_string()
+        .contains("Only admin can migrate contract"));
+
+    // Calling `migrate` entrypoint should now fail, because it is not implemented in contract.
+    let res = app.migrate_contract(admin_addr, contract_addr, &Empty {}, 1);
+
+    assert!(res
+        .unwrap_err()
+        .root_cause()
+        .to_string()
+        .contains("migrate is not implemented for contract"));
+}

--- a/tests/test_contract_wrapper/test_sudo_entrypoint.rs
+++ b/tests/test_contract_wrapper/test_sudo_entrypoint.rs
@@ -1,0 +1,158 @@
+#[test]
+fn sudo_entrypoint_should_work() {
+    use cosmwasm_std::{from_json, Empty};
+    use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
+
+    // Contract definition.
+    mod the_contract {
+        use cosmwasm_schema::cw_serde;
+        use cosmwasm_std::{
+            to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+        };
+
+        #[cw_serde]
+        pub struct SudoMsg {
+            pub some_string: String,
+        }
+
+        pub fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+            to_json_binary(&Empty {})
+        }
+
+        pub fn sudo(_deps: DepsMut, _env: Env, msg: SudoMsg) -> StdResult<Response> {
+            Ok(Response::default().set_data(to_json_binary(&msg)?))
+        }
+    }
+
+    use the_contract::*;
+
+    // Returns the wrapped contract.
+    pub fn contract() -> Box<dyn Contract<Empty>> {
+        Box::new(ContractWrapper::new(execute, instantiate, query).with_sudo(sudo))
+    }
+
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the contract code on chain.
+    let code_id = app.store_code(contract());
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Instantiate the contract.
+    let contract_addr = app
+        .instantiate_contract(
+            code_id,
+            owner_addr.clone(),
+            &Empty {},
+            &[],
+            "the-contract",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Calling `sudo` entrypoint should work.
+    let msg = SudoMsg {
+        some_string: "some string".to_string(),
+    };
+    let app_response = app.wasm_sudo(contract_addr, &msg).unwrap();
+    let response_msg: SudoMsg = from_json(app_response.data.unwrap()).unwrap();
+    assert_eq!("some string", response_msg.some_string);
+}
+
+#[test]
+fn sudo_empty_entrypoint_should_work() {
+    use cosmwasm_std::Empty;
+    use cw_multi_test::{App, Contract, ContractWrapper, Executor, IntoAddr};
+
+    // Contract definition.
+    mod the_contract {
+        use cosmwasm_std::{
+            to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+        };
+
+        pub fn instantiate(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn execute(
+            _deps: DepsMut,
+            _env: Env,
+            _info: MessageInfo,
+            _msg: Empty,
+        ) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+
+        pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+            to_json_binary(&Empty {})
+        }
+
+        pub fn sudo(_deps: DepsMut, _env: Env, _msg: Empty) -> StdResult<Response> {
+            Ok(Response::default())
+        }
+    }
+
+    // Returns the wrapped contract.
+    pub fn contract() -> Box<dyn Contract<Empty>> {
+        Box::new(
+            ContractWrapper::new(
+                the_contract::execute,
+                the_contract::instantiate,
+                the_contract::query,
+            )
+            .with_sudo_empty(the_contract::sudo),
+        )
+    }
+
+    // Initialize the chain.
+    let mut app = App::default();
+
+    // Store the contract code on chain.
+    let code_id = app.store_code(contract());
+
+    // Prepare addresses.
+    let owner_addr = "owner".into_addr();
+    let admin_addr = "admin".into_addr();
+
+    // Instantiate the contract.
+    let contract_addr = app
+        .instantiate_contract(
+            code_id,
+            owner_addr.clone(),
+            &Empty {},
+            &[],
+            "the-contract",
+            Some(admin_addr.to_string()),
+        )
+        .unwrap();
+
+    // Calling `sudo` entrypoint should work.
+    let res = app.wasm_sudo(contract_addr, &Empty {}).unwrap();
+    assert_eq!(None, res.data);
+}

--- a/tests/test_module/test_failing_module.rs
+++ b/tests/test_module/test_failing_module.rs
@@ -9,7 +9,7 @@ fn assert_results(failing_module: FailingModule<Empty, Empty, Empty>) {
     let empty_msg = Empty {};
     let mut storage = MockStorage::default();
     assert_eq!(
-        format!(r#"Unexpected exec msg Empty from Addr("{}")"#, sender_addr),
+        format!(r#"Unexpected exec msg Empty from Addr("{sender_addr}")"#),
         failing_module
             .execute(
                 app.api(),


### PR DESCRIPTION
Backport of the change implemented in version 3.0.0 to version 2.4.0. Will be released as version 2.5.0.

- Editorial changes in README.md.
- Anyhow/backtrace requires now Rust 1.82
- Fixed clippy warnings. Upgraded dependencies.
- Refactored contract interface.
- Added `MigrateInfo`.
- Added tests.

---
closes #258 