### PR TITLE
Removed clippy.toml

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-too-many-arguments-threshold = 12

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -155,6 +155,7 @@ pub trait AddressGenerator {
     /// assert_ne!(addr12, addr22);
     /// assert_ne!(addr21, addr22);
     /// ```
+    #[allow(clippy::too_many_arguments)]
     fn predictable_contract_address(
         &self,
         api: &dyn Api,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -107,6 +107,7 @@ where
     /// This is a helper function around [execute][Self::execute] function
     /// with `WasmMsg::Instantiate2` message.
     #[cfg(feature = "cosmwasm_1_2")]
+    #[allow(clippy::too_many_arguments)]
     fn instantiate2_contract<M, L, A, S>(
         &mut self,
         code_id: u64,

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -428,6 +428,7 @@ impl StakeKeeper {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_stake(
         &self,
         api: &dyn Api,

--- a/src/stargate.rs
+++ b/src/stargate.rs
@@ -12,6 +12,7 @@ use serde::de::DeserializeOwned;
 /// and `Stargate`/`Grpc` queries.
 pub trait Stargate {
     /// Processes `CosmosMsg::Stargate` message variant.
+    #[allow(clippy::too_many_arguments)]
     fn execute_stargate<ExecC, QueryC>(
         &self,
         _api: &dyn Api,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -560,6 +560,7 @@ where
         data.into()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn send<T>(
         &self,
         api: &dyn Api,
@@ -770,6 +771,7 @@ where
     }
 
     /// Processes WasmMsg::Instantiate and WasmMsg::Instantiate2 messages.
+    #[allow(clippy::too_many_arguments)]
     fn process_wasm_msg_instantiate(
         &self,
         api: &dyn Api,
@@ -990,6 +992,7 @@ where
         (app_response, messages)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_response(
         &self,
         api: &dyn Api,
@@ -1033,6 +1036,7 @@ where
     ///
     /// You have to call init after this to set up the contract properly.
     /// These two steps are separated to have cleaner return values.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_contract(
         &self,
         api: &dyn Api,
@@ -1088,6 +1092,7 @@ where
     }
 
     /// Executes contract's `execute` entry-point.
+    #[allow(clippy::too_many_arguments)]
     pub fn call_execute(
         &self,
         api: &dyn Api,
@@ -1109,6 +1114,7 @@ where
     }
 
     /// Executes contract's `instantiate` entry-point.
+    #[allow(clippy::too_many_arguments)]
     pub fn call_instantiate(
         &self,
         address: Addr,
@@ -1192,6 +1198,7 @@ where
 
     /// Executes contract's `migrate` entry-point.
     #[cfg(feature = "cosmwasm_2_2")]
+    #[allow(clippy::too_many_arguments)]
     pub fn call_migrate(
         &self,
         address: Addr,


### PR DESCRIPTION
Removed global clippy configuration which was used just for changing the `too-many-arguments-threshold`.
It is better for newcomers to have to place an annotation before function, instead of thinking that developing functions with too many arguments is a good practice. Existing functions having too many arguments are preserved and annotated with: `#[allow(clippy::too_many_arguments)]`.