### PR TITLE
Unified header information README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # MultiTest
 
-[![cw-multi-test][crates-badge]][crates-url]
-[![docs][docs-badge]][docs-url]
-![coverage][coverage-badge]
+![component][component-badge]
 [![license][apache-badge]][apache-url]
 
+[component-badge]: https://img.shields.io/badge/CosmWasm_component-6343ae.svg
 [crates-badge]: https://img.shields.io/crates/v/cw-multi-test.svg
 [crates-url]: https://crates.io/crates/cw-multi-test
 [docs-badge]: https://docs.rs/cw-multi-test/badge.svg
@@ -16,6 +15,14 @@
 [CosmWasm]: https://github.com/CosmWasm
 
 **Testing tools for multi-contract interactions**
+
+## Rust crates
+
+The following Rust crates are maintained in this repository:
+
+| Crate         | Usage            | Download                                     | Docs                            | Coverage                    |
+|---------------|------------------|----------------------------------------------|---------------------------------|-----------------------------|
+| cw-multi-test | Contract testing | [![cw-multi-test][crates-badge]][crates-url] | [![docs][docs-badge]][docs-url] | ![coverage][coverage-badge] |
 
 ## Introduction
 


### PR DESCRIPTION
Unified the content of the top part of the README file, which now contains:
- Badge pointing out that this repo is a CosmWasm component.
- List of Rust crates mainteined in this repository.
- Crate info: name, usage, download link, documentation link, detailed coverage stats.