### PR TITLE
Upgrade checkout action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt -- --check
       - run: cargo clippy --all-features --all-targets -- -D warnings
@@ -14,27 +14,27 @@ jobs:
   build-default-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build
+      - run: cargo build --locked
 
   build-all-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --all-features
+      - run: cargo build --locked --all-features
 
   test-default-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+      - run: cargo test --locked
 
   test-all-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --all-features
+      - run: cargo test --locked --all-features

--- a/src/app.rs
+++ b/src/app.rs
@@ -429,7 +429,7 @@ where
 
     /// Simple helper so we get access to all the QuerierWrapper helpers,
     /// e.g. wrap().query_wasm_smart, query_all_balances, ...
-    pub fn wrap(&self) -> QuerierWrapper<CustomT::QueryT> {
+    pub fn wrap(&self) -> QuerierWrapper<'_, CustomT::QueryT> {
         QuerierWrapper::new(self)
     }
 
@@ -728,6 +728,7 @@ where
     }
 }
 
+/// Router for mocking purposes.
 pub struct MockRouter<ExecC, QueryC>(PhantomData<(ExecC, QueryC)>);
 
 impl Default for MockRouter<Empty, Empty> {
@@ -737,6 +738,7 @@ impl Default for MockRouter<Empty, Empty> {
 }
 
 impl<ExecC, QueryC> MockRouter<ExecC, QueryC> {
+    /// Creates a new [MockRouter].
     pub fn new() -> Self
     where
         QueryC: CustomQuery,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ pub use crate::addresses::{
 };
 pub use crate::api::{MockApiBech32, MockApiBech32m};
 pub use crate::app::{
-    custom_app, next_block, no_init, App, BasicApp, CosmosRouter, Router, SudoMsg,
+    custom_app, next_block, no_init, App, BasicApp, CosmosRouter, MockRouter, Router, SudoMsg,
 };
 pub use crate::app_builder::{AppBuilder, BasicAppBuilder};
 pub use crate::bank::{Bank, BankKeeper, BankSudo};


### PR DESCRIPTION
- Upgraded to `actions/checkout@5`.
- Locked dependencies in build and test actions.
- Fixed clippy warnings.
- Made MockRouter public, otherwise it should be deleted - to be removed in future versions.